### PR TITLE
feat: add smb dialect protocol versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 Cargo.lock
 coverage/
 lcov*.info
+.superpowers/
+.claude/
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,38 +1,90 @@
 # Changelog
 
-- [Changelog](#changelog)
-  - [0.3.1](#031)
-  - [0.3.0](#030)
-  - [0.2.1](#021)
-  - [0.2.0](#020)
-  - [0.1.0](#010)
+All notable changes to this project are documented in this file.
 
----
+## 0.4.0
+
+Released on 2026-09-02
+
+### Added
+
+- add smb dialect protocol versions
+
+> Expose a shared dialect API, enforce secure SMB2 and SMB3 negotiation bounds on Unix, and provide cross-platform constructor parity on Windows.
+
+### Fixed
+
+- mark smb client doctest as no_run so it does not need a live server
+
+> The lib.rs example connects to a live SMB server unconditionally,
+> unlike the with-containers-gated unit tests, so `just test` failed
+> without Docker running. no_run keeps it compiled and type-checked
+> without executing it.
+
+- create container test fixtures over SMB instead of the host fs
+
+> The samba container's entrypoint recursively chowns/chmods the
+> bind-mounted share root, which on Linux CI runners strips write access
+> from the host's shared /tmp for the CI user. init_client/finalize_client
+> used to mkdir/rmdir /cargo-test directly on the host, so every
+> with-containers test failed with a permission error before ever
+> exercising the client.
+
+### Build
+
+- bump pavao to 0.3.0
 
 ## 0.3.1
 
-Released on 20/03/2025
+Released on 2025-03-20
 
+### Fixed
+
+- test is sync and send
 - added `vendored` feature to vendor `libsmbclient`
 
 ## 0.3.0
 
-Released on 30/09/2024
+Released on 2024-09-30
 
-- remotefs `0.3.0`
+### Added
+
+- remotefs 0.3
+
+### Fixed
+
+- ci
+- lint
 
 ## 0.2.1
 
-Released on 15/12/2023
+Released on 2023-12-15
 
-- Fixed windows build #2
+### Added
+
+- 0.2.1
 
 ## 0.2.0
 
-- Windows support
+Released on 2023-05-13
+
+### Added
+
+- windows client
+- windows SmbCredentials
+- example
+- windows client
+
+### Fixed
+
+- removed utils from windows
+- lint
+- macos types
+- borrow path
+- tests
+- removed macos tests
+- env! SMB_SHARE/SMB_SERVER
 
 ## 0.1.0
 
-Released on 27/05/2022
-
-- First release
+Released on 2022-05-27

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,6 +2,59 @@
 //!
 //! Smb fs client
 
+/// An SMB protocol dialect used to bound protocol negotiation.
+///
+/// Variants are ordered from oldest to newest. [`SmbDialect::Nt1`] is the
+/// deprecated SMB1/CIFS dialect and must be selected explicitly.
+///
+/// # Examples
+///
+/// ```
+/// use remotefs_smb::SmbDialect;
+///
+/// assert!(SmbDialect::Smb202 < SmbDialect::Smb311);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SmbDialect {
+    /// The deprecated SMB1/CIFS `NT1` dialect.
+    Nt1,
+    /// The SMB 2.0.2 dialect.
+    Smb202,
+    /// The SMB 2.1 dialect.
+    Smb210,
+    /// The SMB 3.0 dialect.
+    Smb300,
+    /// The SMB 3.0.2 dialect.
+    Smb302,
+    /// The SMB 3.1.1 dialect.
+    Smb311,
+}
+
+const AUTO_MIN_DIALECT: SmbDialect = SmbDialect::Smb202;
+const AUTO_MAX_DIALECT: SmbDialect = SmbDialect::Smb311;
+
+#[cfg(test)]
+mod test {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn should_use_secure_auto_dialect_bounds() {
+        assert_eq!(AUTO_MIN_DIALECT, SmbDialect::Smb202);
+        assert_eq!(AUTO_MAX_DIALECT, SmbDialect::Smb311);
+        assert_ne!(AUTO_MIN_DIALECT, SmbDialect::Nt1);
+    }
+
+    #[test]
+    fn should_copy_dialects() {
+        let dialect = SmbDialect::Smb302;
+        let copied = dialect;
+        assert_eq!(copied, SmbDialect::Smb302);
+        assert_eq!(dialect, SmbDialect::Smb302);
+    }
+}
+
 // -- unix client
 
 #[cfg(target_family = "unix")]

--- a/src/client/unix.rs
+++ b/src/client/unix.rs
@@ -12,7 +12,21 @@ use pavao::{SmbDirentType, SmbMode, SmbOpenOptions};
 use remotefs::fs::{File, Metadata, ReadStream, UnixPex, Welcome, WriteStream};
 use remotefs::{RemoteError, RemoteErrorType, RemoteFs, RemoteResult};
 
+use super::{SmbDialect, AUTO_MAX_DIALECT, AUTO_MIN_DIALECT};
 use crate::utils::{path as path_utils, smb as smb_utils};
+
+impl From<SmbDialect> for pavao::SmbDialect {
+    fn from(value: SmbDialect) -> Self {
+        match value {
+            SmbDialect::Nt1 => Self::Nt1,
+            SmbDialect::Smb202 => Self::Smb202,
+            SmbDialect::Smb210 => Self::Smb210,
+            SmbDialect::Smb300 => Self::Smb300,
+            SmbDialect::Smb302 => Self::Smb302,
+            SmbDialect::Smb311 => Self::Smb311,
+        }
+    }
+}
 
 /// SMB file system client
 pub struct SmbFs {
@@ -21,12 +35,72 @@ pub struct SmbFs {
 }
 
 impl SmbFs {
-    /// Try to create a new `SmbFs`.
-    /// Fails if it is not possible to instantiate a smb context.
+    /// Tries to create an SMB client with secure automatic dialect bounds.
+    ///
+    /// Automatic negotiation is limited to SMB2 through SMB3.1.1 and excludes
+    /// the deprecated SMB1/CIFS `NT1` dialect.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RemoteErrorType::BadAddress`] if Pavao cannot initialize the
+    /// SMB context.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use remotefs_smb::{SmbCredentials, SmbFs, SmbOptions};
+    ///
+    /// let _client = SmbFs::try_new(
+    ///     SmbCredentials::default()
+    ///         .server("smb://server.example")
+    ///         .share("/documents"),
+    ///     SmbOptions::default(),
+    /// )?;
+    /// # Ok::<(), remotefs::RemoteError>(())
+    /// ```
     pub fn try_new(credentials: SmbCredentials, options: SmbOptions) -> RemoteResult<Self> {
+        Self::try_new_with_dialect(credentials, options, AUTO_MIN_DIALECT, AUTO_MAX_DIALECT)
+    }
+
+    /// Tries to create an SMB client with inclusive protocol dialect bounds.
+    ///
+    /// The client applies `min_dialect` and `max_dialect` to Pavao after
+    /// preserving all other settings in `options`. An inverted range is
+    /// rejected. Selecting [`SmbDialect::Nt1`] enables deprecated SMB1/CIFS
+    /// negotiation and should be reserved for legacy devices that require it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RemoteErrorType::BadAddress`] if the bounds are invalid or
+    /// Pavao cannot initialize the SMB context.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use remotefs_smb::{SmbCredentials, SmbDialect, SmbFs, SmbOptions};
+    ///
+    /// let _client = SmbFs::try_new_with_dialect(
+    ///     SmbCredentials::default()
+    ///         .server("smb://server.example")
+    ///         .share("/documents"),
+    ///     SmbOptions::default(),
+    ///     SmbDialect::Smb202,
+    ///     SmbDialect::Smb210,
+    /// )?;
+    /// # Ok::<(), remotefs::RemoteError>(())
+    /// ```
+    pub fn try_new_with_dialect(
+        credentials: SmbCredentials,
+        options: SmbOptions,
+        min_dialect: SmbDialect,
+        max_dialect: SmbDialect,
+    ) -> RemoteResult<Self> {
+        let options = options
+            .min_protocol(min_dialect.into())
+            .max_protocol(max_dialect.into());
         Ok(Self {
             client: SmbClient::new(credentials, options)
-                .map_err(|e| RemoteError::new_ex(RemoteErrorType::BadAddress, e))?,
+                .map_err(|error| RemoteError::new_ex(RemoteErrorType::BadAddress, error))?,
             wrkdir: PathBuf::from("/"),
         })
     }
@@ -287,10 +361,68 @@ mod test {
     #[cfg(feature = "with-containers")]
     use std::time::Duration;
 
-    #[cfg(feature = "with-containers")]
     use serial_test::serial;
 
     use super::*;
+
+    #[test]
+    fn should_convert_all_dialects_to_pavao() {
+        assert_eq!(
+            pavao::SmbDialect::from(SmbDialect::Nt1),
+            pavao::SmbDialect::Nt1
+        );
+        assert_eq!(
+            pavao::SmbDialect::from(SmbDialect::Smb202),
+            pavao::SmbDialect::Smb202
+        );
+        assert_eq!(
+            pavao::SmbDialect::from(SmbDialect::Smb210),
+            pavao::SmbDialect::Smb210
+        );
+        assert_eq!(
+            pavao::SmbDialect::from(SmbDialect::Smb300),
+            pavao::SmbDialect::Smb300
+        );
+        assert_eq!(
+            pavao::SmbDialect::from(SmbDialect::Smb302),
+            pavao::SmbDialect::Smb302
+        );
+        assert_eq!(
+            pavao::SmbDialect::from(SmbDialect::Smb311),
+            pavao::SmbDialect::Smb311
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn should_reject_inverted_dialect_bounds() {
+        let result = SmbFs::try_new_with_dialect(
+            test_credentials(),
+            SmbOptions::default(),
+            SmbDialect::Smb311,
+            SmbDialect::Nt1,
+        );
+
+        assert_eq!(
+            result.err().expect("inverted bounds must fail").kind,
+            RemoteErrorType::BadAddress,
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn should_default_to_secure_auto_dialect_bounds() {
+        let default_client = SmbFs::try_new(test_credentials(), SmbOptions::default()).unwrap();
+        let explicit_auto_client = SmbFs::try_new_with_dialect(
+            test_credentials(),
+            SmbOptions::default(),
+            SmbDialect::Smb202,
+            SmbDialect::Smb311,
+        );
+
+        assert!(explicit_auto_client.is_ok());
+        drop(default_client);
+    }
 
     #[test]
     #[cfg(feature = "with-containers")]
@@ -818,15 +950,19 @@ mod test {
 
     fn is_sync<T: Sync>(_sync: T) {}
 
+    fn test_credentials() -> SmbCredentials {
+        SmbCredentials::default()
+            .server("smb://localhost:3445")
+            .share("/temp")
+            .username("test")
+            .password("test")
+            .workgroup("pavao")
+    }
+
     #[test]
     fn test_should_be_sync() {
         let client = SmbFs::try_new(
-            SmbCredentials::default()
-                .server("smb://localhost:3445")
-                .share("/temp")
-                .username("test")
-                .password("test")
-                .workgroup("pavao"),
+            test_credentials(),
             SmbOptions::default()
                 .case_sensitive(true)
                 .one_share_per_server(true),
@@ -839,12 +975,7 @@ mod test {
     #[test]
     fn test_should_be_send() {
         let client = SmbFs::try_new(
-            SmbCredentials::default()
-                .server("smb://localhost:3445")
-                .share("/temp")
-                .username("test")
-                .password("test")
-                .workgroup("pavao"),
+            test_credentials(),
             SmbOptions::default()
                 .case_sensitive(true)
                 .one_share_per_server(true),
@@ -857,12 +988,7 @@ mod test {
     #[cfg(feature = "with-containers")]
     fn init_client() -> SmbFs {
         let mut client = SmbFs::try_new(
-            SmbCredentials::default()
-                .server("smb://localhost:3445")
-                .share("/temp")
-                .username("test")
-                .password("test")
-                .workgroup("pavao"),
+            test_credentials(),
             SmbOptions::default()
                 .case_sensitive(true)
                 .one_share_per_server(true),

--- a/src/client/windows.rs
+++ b/src/client/windows.rs
@@ -17,6 +17,8 @@ use remotefs::{RemoteError, RemoteErrorType, RemoteFs, RemoteResult};
 use windows_sys::Win32::Foundation::{NO_ERROR, TRUE};
 use windows_sys::Win32::NetworkManagement::WNet;
 
+use super::{SmbDialect, AUTO_MAX_DIALECT, AUTO_MIN_DIALECT};
+
 /// SMB file system client
 pub struct SmbFs {
     remote_path: PathBuf,
@@ -27,9 +29,53 @@ pub struct SmbFs {
 }
 
 impl SmbFs {
-    /// Instantiates a new SmbFs
+    /// Instantiates an SMB client with secure automatic dialect bounds.
+    ///
+    /// The portable policy represented by this constructor allows SMB2 through
+    /// SMB3.1.1 and excludes the deprecated SMB1/CIFS `NT1` dialect. The
+    /// Windows redirector ultimately applies the operating system's SMB
+    /// negotiation policy.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use remotefs_smb::{SmbCredentials, SmbFs};
+    ///
+    /// let _client = SmbFs::new(SmbCredentials::new("server.example", "documents"));
+    /// ```
     pub fn new(credentials: SmbCredentials) -> Self {
-        let remote_name = format!("\\\\{}\\{}", credentials.server, credentials.share);
+        Self::new_with_dialect(credentials, AUTO_MIN_DIALECT, AUTO_MAX_DIALECT)
+    }
+
+    /// Instantiates an SMB client with cross-platform dialect bounds.
+    ///
+    /// Windows' native `WNetAddConnection2A` redirector API does not expose
+    /// per-connection SMB dialect bounds. The `min_dialect` and `max_dialect`
+    /// arguments are therefore accepted for API parity but are not enforced;
+    /// the operating system manages protocol negotiation. In particular,
+    /// selecting [`SmbDialect::Nt1`] here does not enable SMB1.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use remotefs_smb::{SmbCredentials, SmbDialect, SmbFs};
+    ///
+    /// let _client = SmbFs::new_with_dialect(
+    ///     SmbCredentials::new("server.example", "documents"),
+    ///     SmbDialect::Smb202,
+    ///     SmbDialect::Smb210,
+    /// );
+    /// ```
+    pub fn new_with_dialect(
+        credentials: SmbCredentials,
+        _min_dialect: SmbDialect,
+        _max_dialect: SmbDialect,
+    ) -> Self {
+        let remote_name = format!(
+            "\\\\{server}\\{share}",
+            server = credentials.server,
+            share = credentials.share,
+        );
         Self {
             remote_path: PathBuf::from(&remote_name),
             remote_name,
@@ -370,6 +416,27 @@ impl RemoteFs for SmbFs {
 mod test {
 
     use super::*;
+
+    #[test]
+    fn should_construct_with_explicit_dialect_bounds() {
+        let client = SmbFs::new_with_dialect(
+            SmbCredentials::new("pippo", "pippo"),
+            SmbDialect::Nt1,
+            SmbDialect::Nt1,
+        );
+
+        assert_eq!(client.remote_name, r"\\pippo\pippo");
+        assert!(!client.is_connected);
+    }
+
+    #[test]
+    fn should_construct_with_secure_auto_defaults() {
+        let client = SmbFs::new(SmbCredentials::new("pippo", "pippo"));
+
+        assert_eq!(AUTO_MIN_DIALECT, SmbDialect::Smb202);
+        assert_eq!(AUTO_MAX_DIALECT, SmbDialect::Smb311);
+        assert!(!client.is_connected);
+    }
 
     #[test]
     #[cfg(feature = "with-containers")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 //! ### Smb client (UNIX)
 //!
 //! Here is a basic usage example, with the `Smb` client.
+//! `SmbFs::try_new` automatically negotiates only SMB2 through SMB3.1.1.
 //!
 //! ```rust,no_run
 //!
@@ -56,6 +57,23 @@
 //! assert!(client.disconnect().is_ok());
 //! ```
 //!
+//! To select a narrower inclusive range explicitly, use
+//! [`SmbFs::try_new_with_dialect`]:
+//!
+//! ```rust,no_run
+//! use remotefs_smb::{SmbCredentials, SmbDialect, SmbFs, SmbOptions};
+//!
+//! let _client = SmbFs::try_new_with_dialect(
+//!     SmbCredentials::default()
+//!         .server("smb://server.example")
+//!         .share("/documents"),
+//!     SmbOptions::default(),
+//!     SmbDialect::Smb202,
+//!     SmbDialect::Smb210,
+//! )?;
+//! # Ok::<(), remotefs::RemoteError>(())
+//! ```
+//!
 
 #![doc(html_playground_url = "https://play.rust-lang.org")]
 #![doc(
@@ -71,6 +89,7 @@ extern crate log;
 
 mod client;
 
+pub use client::SmbDialect;
 #[cfg(target_family = "unix")]
 pub use client::{SmbCredentials, SmbEncryptionLevel, SmbFs, SmbOptions, SmbShareMode};
 #[cfg(target_family = "windows")]


### PR DESCRIPTION
# Description

Adds a shared SMB dialect type and dialect-aware constructors for Unix and Windows. Unix now limits automatic negotiation to SMB2 through SMB3.1.1 and applies explicit bounds. Windows accepts the same API while continuing to follow operating system policy.

Fixes: none

## Checklist

- [x] I have read the [AI Policy](https://github.com/remotefs-rs/remotefs-rs-smb/blob/main/AI_POLICY.md) and the [contributing guidelines](https://github.com/remotefs-rs/remotefs-rs-smb/blob/main/CONTRIBUTING.md).
- [x] I have added rustdoc documentation for any new public API.
- [x] I have added tests covering my changes.
- [x] just check passes locally.
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org) format. The CHANGELOG.md file is generated from them at release time.

## AI Disclosure

Codex was used to implement the planned change, write tests and rustdoc, run verification commands, and prepare this pull request. I reviewed the resulting changes and test output.

## Notes

The Windows GNU target was not installed locally, so Windows compilation remains for CI.