### PR TITLE
feat!: add rust-native smb client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y libsmbclient-dev libsmbclient
       - name: Lint
-        run: cargo clippy --all-targets --features find -- -D warnings
+        run: cargo clippy --all-targets --features find,pavao,smb -- -D warnings
 
   quality-linux:
     name: Quality (Linux)
@@ -68,9 +68,9 @@ jobs:
         with:
           tool: cargo-llvm-cov
       - name: Build
-        run: just build "--no-default-features --features find,with-containers"
+        run: just build "--no-default-features --features find,pavao,smb,with-containers"
       - name: Test with coverage
-        run: just coverage "lcov.info" "--no-default-features --features find,with-containers"
+        run: just coverage "lcov.info" "--no-default-features --features find,pavao,smb,with-containers"
         env:
           RUST_LOG: trace
       - name: Upload to Coveralls
@@ -91,9 +91,9 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
       - name: Build
-        run: just build "--features find"
+        run: just build "--features find,pavao,smb"
       - name: Lint
-        run: cargo clippy --features find -- -D warnings
+        run: cargo clippy --all-targets --features find,pavao,smb -- -D warnings
 
   quality-windows:
     name: Quality (Windows)
@@ -105,13 +105,13 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
       - name: Build
-        run: just build "--features find"
+        run: just build "--features find,pavao,smb"
       - name: Test
-        run: cargo test --lib --no-default-features --features find --no-fail-fast
+        run: cargo test --lib --no-default-features --features find,smb --no-fail-fast
         env:
           RUST_LOG: trace
       - name: Lint
-        run: cargo clippy --features find -- -D warnings
+        run: cargo clippy --all-targets --features find,pavao,smb -- -D warnings
 
   documentation:
     name: Documentation
@@ -123,7 +123,7 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y libsmbclient-dev libsmbclient
       - name: Build documentation
-        run: RUSTDOCFLAGS="-D warnings" cargo doc --features find --no-deps
+        run: RUSTDOCFLAGS="-D warnings" cargo doc --features find,pavao,smb --no-deps
 
   dependencies:
     name: Dependencies

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -29,4 +29,4 @@ jobs:
         with:
           base: ""
           head: HEAD
-          extra_args: --results=verified,unknown --fail-on-scan-errors
+          extra_args: --results=verified,unknown --fail-on-scan-errors --force-skip-binaries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,23 @@
 
 All notable changes to this project are documented in this file.
 
-## 0.4.1
+## 0.5.0
+
+Released on 2026-09-02
+
+### Breaking changes
+
+- add rust-native smb client
+
+> the pavao client types are now PavaoSmbFs, PavaoSmbCredentials, PavaoSmbOptions, PavaoSmbEncryptionLevel, and PavaoSmbShareMode; the Windows client types are now WNetSmbFs and WNetSmbCredentials. The plain SmbFs, SmbCredentials, SmbOptions, and SmbEncryptionLevel names belong to the new Rust-native client behind the smb feature.
+
+### Added
+
+- Breaking: add rust-native smb client
+
+> Add SmbFs, a RemoteFs implementation built on the pure-Rust smb crate, gated behind the new smb feature and driven by a caller-supplied Tokio runtime. Gate the libsmbclient client behind the pavao feature (still on by default) so both clients build together, document all clients, and bump to 0.5.0.
+
+## 0.4.0
 
 Released on 2026-09-02
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,8 @@ just test                  # cargo test --lib, then --doc
 just coverage              # cargo llvm-cov, writes lcov.info
 just fmt                   # dprint fmt (Markdown, Rust, TOML, YAML)
 just fmt_check             # dprint check
-just lint "-- -D warnings" # alias of `just clippy`, runs with --all-features
-just doc                   # cargo doc --all-features with RUSTDOCFLAGS="-D warnings"
+just lint "-- -D warnings" # alias of just clippy
+just doc                   # cargo doc --no-deps with RUSTDOCFLAGS="-D warnings"
 just deny                  # cargo deny check
 just scan_secrets          # trufflehog filesystem
 just check                 # the full local quality gate
@@ -32,19 +32,23 @@ just publish "--dry-run --allow-dirty"
 `just check` is the required gate before declaring work done. It chains
 `fmt_check`, Clippy with warnings denied, `doc`, `deny`, and `test`.
 
-`just lint` and `just doc` run with `--all-features`, which includes
-`vendored` (builds `libsmbclient` from vendored sources via `pavao`). That
-build is not exercised in CI (see Architecture below) because it has not been
-verified to succeed unattended; if you touch anything under the `vendored`
-feature, build it locally with `cargo build --features vendored` first.
+`just clippy`, `just doc`, and `just test` build with default features
+(`find`, `pavao`). `just check` passes `--features smb` to them so the
+Rust-native client is linted, documented, and unit-tested together with the
+pavao client. Never pass `--all-features`: it includes `vendored` (builds
+`libsmbclient` from vendored sources via `pavao`), which is not exercised in CI
+because it has not been verified to succeed unattended; if you touch anything
+under the `vendored` feature, build it locally with `just build
+"--features vendored"` first.
 
-Almost every test in `src/client/unix.rs` and most of `src/client/windows.rs`
-is gated behind the `with-containers` feature and needs the Samba container
-from `tests/docker-compose.yml` running locally
+Almost every test in `src/client/unix.rs`, `src/client/rust_smb.rs`, and most
+of `src/client/windows.rs` is gated behind the `with-containers` feature and
+needs the Samba container from `tests/docker-compose.yml` running locally
 (`docker compose -f tests/docker-compose.yml up -d --build`) before
-`just test "--no-default-features --features find,with-containers"` will pass.
-Tests in `src/client/windows/credentials.rs` are plain unit tests and need no
-container.
+`just test "--no-default-features --features find,pavao,smb,with-containers"`
+will pass. Tests in `src/client/windows/credentials.rs` and in the `rust_smb`
+submodules (`credentials`, `options`, `convert`) are plain unit tests and need
+no container.
 
 If a required tool is missing, say so. Never claim a check passed or silently
 swap in a weaker command.
@@ -53,24 +57,28 @@ swap in a weaker command.
 
 remotefs-smb is a [remotefs](https://github.com/remotefs-rs/remotefs-rs)
 client implementation providing SMB access. It is a library-only crate
-(`src/lib.rs`, crate name `remotefs_smb`), with one example binary
-(`examples/tree.rs`).
+(`src/lib.rs`, crate name `remotefs_smb`), with two example binaries:
+`examples/tree.rs` and `examples/tree_rs.rs`.
 
-- **Platform split, not a feature split.** Unlike sibling remotefs backends,
-  SMB support is not chosen via Cargo feature: `src/client/unix.rs`
-  (`#[cfg(target_family = "unix")]`) wraps `pavao`/`libsmbclient`, and
-  `src/client/windows.rs` (`#[cfg(target_family = "windows")]`) uses the
-  Win32 `WNet` API through `windows-sys`. Both are compiled into whichever
-  target family you build for; there is no way to select one on the other's
-  platform.
+- **Three clients, prefixed by backend.** `src/client/rust_smb.rs`
+  (`#[cfg(feature = "smb")]`) exposes `SmbFs`/`SmbCredentials`/
+  `SmbOptions` on every platform by wrapping the pure-Rust `smb` crate,
+  driven through a caller-supplied Tokio runtime with `block_on`.
+  `src/client/unix.rs`
+  (`#[cfg(all(target_family = "unix", feature = "pavao"))]`) exposes
+  `PavaoSmbFs` and re-exports pavao's types with a `Pavao` prefix.
+  `src/client/windows.rs` (`#[cfg(target_family = "windows")]`) exposes
+  `WNetSmbFs`/`WNetSmbCredentials` over the Win32 `WNet` API and is always
+  compiled on Windows. `pavao` and `smb` must build together; `pavao` is a
+  default feature and `vendored` implies it.
 - **Command layer.** `Justfile` is a thin importer. Each recipe group lives in
   its own file under `just/` (`build`, `test`, `code_check`, `changelog`,
   `publish`) and carries a `[group(...)]` attribute so `just --list` stays
   organized. Recipes take an `args=""` passthrough rather than hard-coding
-  flags, except `clippy`/`lint` and `doc`, which hard-code `--all-features`.
+  flags.
 - **Formatting is dprint, not cargo fmt.** `dprint.json` owns Markdown, TOML,
   and YAML, and delegates `.rs` files to nightly rustfmt through its exec
-  plugin (`--edition 2021`, matching this crate's `package.edition`).
+  plugin (`--edition 2024`, matching this crate's `package.edition`).
   `rustfmt.toml` uses nightly-only options (`imports_granularity`,
   `group_imports`), which is why nightly is required. Always format with
   `just fmt`.
@@ -81,18 +89,21 @@ client implementation providing SMB access. It is a library-only crate
   `yanked = "deny"`, `unmaintained = "all"`, wildcard versions denied, and
   crates.io as the only allowed source. Runs with `all-features = true`, so
   the `vendored` feature's dependency tree is still checked even though it is
-  not built in CI.
+  not built in CI. `deny.toml` ignores RUSTSEC-2023-0071 (`rsa`, transitive
+  through `smb` → `sspi` → `picky`) because no fixed release exists; re-check
+  on every `smb`/`sspi` bump.
 - **CI only runs the container-backed test suite on Linux.** GitHub's macOS
   and Windows runners cannot run the `dperson/samba` container the tests
   connect to, so `.github/workflows/ci.yml`'s `quality-macos` and
   `quality-windows` jobs build and lint but do not run the `with-containers`
-  suite; `quality-linux` is the job that spins up
-  `tests/docker-compose.yml` and uploads coverage.
+  suite; `quality-macos` and `quality-windows` build and lint with
+  `find,pavao,smb`, while `quality-linux` builds and tests with
+  `find,pavao,smb,with-containers` and uploads coverage.
 
 ## Conventions
 
 - Toolchain is pinned to Rust 1.98.0 (`rust-toolchain.toml`). `package.edition`
-  in `Cargo.toml` is 2021; do not bump it as part of unrelated changes.
+  in `Cargo.toml` is 2024; do not bump it as part of unrelated changes.
 - Public library items need canonical rustdoc, including a runnable example.
   `just test` runs doctests, and `just doc` denies warnings.
 - Keep `Cargo.toml` dependency and feature entries alphabetically sorted, with

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remotefs-smb"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Christian Visintin <christian.visintin@veeso.dev>"]
 categories = ["network-programming"]
 documentation = "https://docs.rs/remotefs-smb"
@@ -11,17 +11,20 @@ keywords = ["remotefs", "smb-client", "smb", "smb2", "smb3"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/remotefs-rs/remotefs-rs-smb"
-rust-version = "1.88.0"
+rust-version = "1.89.0"
 description = "remotefs SMB client library"
 
 [dependencies]
+futures-util = { version = "0.3", optional = true }
 log = "0.4"
-remotefs = "^0.3"
+remotefs = "0.3"
+smb = { version = "0.11", default-features = false, features = ["async", "compress", "encrypt", "sign"], optional = true }
+tokio = { version = "1", features = ["rt", "rt-multi-thread"], optional = true }
 
 [target."cfg(target_family = \"unix\")"]
 [target."cfg(target_family = \"unix\")".dependencies]
-libc = "0.2"
-pavao = "0.3"
+libc = { version = "0.2", optional = true }
+pavao = { version = "0.3", optional = true }
 
 [target."cfg(target_family = \"windows\")"]
 [target."cfg(target_family = \"windows\")".dependencies]
@@ -29,7 +32,7 @@ filetime = "0.2"
 windows-sys = { version = "0.61", features = ["Win32_NetworkManagement_WNet", "Win32_Foundation"] }
 
 [dev-dependencies]
-anyhow = "^1"
+anyhow = "1"
 argh = "0.1"
 env_logger = "0.11"
 pretty_assertions = "1"
@@ -38,18 +41,28 @@ serial_test = "3"
 tempfile = "3"
 
 [features]
-default = ["find"]
+default = ["find", "pavao"]
+# clients
+pavao = ["dep:libc", "dep:pavao"]
+smb = ["dep:futures-util", "dep:smb", "dep:tokio"]
 # misc
 find = ["remotefs/find"]
 no-log = ["log/max_level_off"]
-vendored = ["pavao/vendored"]
+vendored = ["pavao", "pavao/vendored"]
 # tests
 with-containers = []
 
 [package.metadata.docs.rs]
-all-features = false
+features = ["find", "pavao", "smb"]
+no-default-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [[example]]
 name = "tree"
 path = "examples/tree.rs"
+required-features = ["pavao"]
+
+[[example]]
+name = "tree_rs"
+path = "examples/tree_rs.rs"
+required-features = ["smb"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">~ Remotefs SMB client ~</p>
 
 <p align="center">Developed by <a href="https://veeso.github.io/" target="_blank">@veeso</a></p>
-<p align="center">Current version: 0.3.1 (20/03/2025)</p>
+<p align="center">Current version: 0.5.0 (02/09/2026)</p>
 
 <p align="center">
   <a href="https://opensource.org/licenses/MIT"
@@ -77,18 +77,28 @@ First of all, add `remotefs-smb` to your project dependencies:
 
 ```toml
 remotefs = "0.3"
-remotefs-smb = "^0.3"
+remotefs-smb = "^0.5"
 ```
 
-these features are supported:
+These features are supported:
 
+- `pavao`: enable the `libsmbclient`-based client on UNIX (_enabled by default_)
+- `smb`: enable the Rust-native client on every platform
 - `find`: enable `find()` method on client (_enabled by default_)
 - `no-log`: disable logging. By default, this library will log via the `log` crate.
-- `vendored`: build pavao with **vendored libsmbclient**
+- `vendored`: build pavao with **vendored libsmbclient** (implies `pavao`)
 
-### Install dependencies (UNIX based only)
+Three clients ship in this crate and can be enabled together:
 
-remotefs-smb relies on `pavao`, which requires the `libsmbclient` library, which can be installed with the following instructions:
+| Client       | Feature | Platforms | Dialects           | System libraries  |
+| ------------ | ------- | --------- | ------------------ | ----------------- |
+| `SmbFs`      | `smb`   | all       | SMB 2.0.2 to 3.1.1 | none              |
+| `PavaoSmbFs` | `pavao` | UNIX      | SMB1 to SMB 3.1.1  | `libsmbclient`    |
+| `WNetSmbFs`  | always  | Windows   | OS managed         | `WNet` (built in) |
+
+### Install dependencies (pavao client only)
+
+The `pavao` feature relies on `pavao`, which requires the `libsmbclient` library, which can be installed with the following instructions:
 
 #### MacOS 🍎
 
@@ -137,13 +147,24 @@ rm -rf samba/
 
 ### Client implementation
 
-#### UNIX client
+#### Rust-native client (all platforms)
+
+Enable the `smb` feature and add `tokio`:
+
+```toml
+remotefs-smb = { version = "^0.5", features = ["smb"] }
+tokio = { version = "1", features = ["rt-multi-thread"] }
+```
 
 ```rust
-// import remotefs trait and client
-use remotefs::{RemoteFs, fs::UnixPex};
-use remotefs_smb::{SmbFs, SmbOptions, SmbCredentials};
 use std::path::Path;
+use std::sync::Arc;
+
+use remotefs::{fs::UnixPex, RemoteFs};
+use remotefs_smb::{SmbCredentials, SmbFs, SmbOptions};
+use tokio::runtime::Runtime;
+
+let runtime = Arc::new(Runtime::new().unwrap());
 let mut client = SmbFs::try_new(
     SmbCredentials::default()
         .server("smb://localhost:3445")
@@ -151,7 +172,41 @@ let mut client = SmbFs::try_new(
         .username("test")
         .password("test")
         .workgroup("pavao"),
-    SmbOptions::default()
+    SmbOptions::default(),
+    &runtime,
+)
+.unwrap();
+// connect
+assert!(client.connect().is_ok());
+// get working directory
+println!("Wrkdir: {}", client.pwd().ok().unwrap().display());
+// make directory
+assert!(client
+    .create_dir(Path::new("/cargo"), UnixPex::from(0o755))
+    .is_ok());
+// change working directory
+assert!(client.change_dir(Path::new("/cargo")).is_ok());
+// disconnect
+assert!(client.disconnect().is_ok());
+```
+
+The runtime must outlive the client and the client must not be called from a task running on that same runtime.
+
+#### Pavao client (UNIX)
+
+```rust
+// import remotefs trait and client
+use remotefs::{RemoteFs, fs::UnixPex};
+use remotefs_smb::{PavaoSmbCredentials, PavaoSmbFs, PavaoSmbOptions};
+use std::path::Path;
+let mut client = PavaoSmbFs::try_new(
+    PavaoSmbCredentials::default()
+        .server("smb://localhost:3445")
+        .share("/temp")
+        .username("test")
+        .password("test")
+        .workgroup("pavao"),
+    PavaoSmbOptions::default()
         .case_sensitive(true)
         .one_share_per_server(true),
 )
@@ -168,15 +223,15 @@ assert!(client.change_dir(Path::new("/cargo")).is_ok());
 assert!(client.disconnect().is_ok());
 ```
 
-#### Windows client
+#### WNet client (Windows)
 
 ```rust
 // import remotefs trait and client
 use remotefs::{RemoteFs, fs::UnixPex};
-use remotefs_smb::{SmbFs, SmbCredentials};
+use remotefs_smb::{WNetSmbCredentials, WNetSmbFs};
 use std::path::Path;
-let mut client = SmbFs::new(
-    SmbCredentials::new("localhost:3445", "temp")
+let mut client = WNetSmbFs::new(
+    WNetSmbCredentials::new("localhost:3445", "temp")
         .username("test")
         .password("test")
 );
@@ -200,28 +255,28 @@ The following table states the compatibility for the client client and the remot
 
 Note: `connect()`, `disconnect()` and `is_connected()` **MUST** always be supported, and are so omitted in the table.
 
-| Client/Method  | Support (UNIX) | Support (Win ) |
-| -------------- | -------------- | -------------- |
-| append_file    | Yes            | Yes            |
-| append         | No             | Yes            |
-| change_dir     | Yes            | Yes            |
-| copy           | No             | Yes            |
-| create_dir     | Yes            | Yes            |
-| create_file    | Yes            | Yes            |
-| create         | No             | Yes            |
-| exec           | No             | No             |
-| exists         | Yes            | Yes            |
-| list_dir       | Yes            | Yes            |
-| mov            | Yes            | Yes            |
-| open_file      | Yes            | Yes            |
-| open           | No             | Yes            |
-| pwd            | Yes            | Yes            |
-| remove_dir_all | Yes            | Yes            |
-| remove_dir     | Yes            | Yes            |
-| remove_file    | Yes            | Yes            |
-| setstat        | No             | Yes            |
-| stat           | Yes            | Yes            |
-| symlink        | Yes            | Yes            |
+| Client/Method  | Rust-native | pavao (UNIX) | WNet (Windows) |
+| -------------- | ----------- | ------------ | -------------- |
+| append_file    | Yes         | Yes          | Yes            |
+| append         | No          | No           | Yes            |
+| change_dir     | Yes         | Yes          | Yes            |
+| copy           | No          | No           | Yes            |
+| create_dir     | Yes         | Yes          | Yes            |
+| create_file    | Yes         | Yes          | Yes            |
+| create         | No          | No           | Yes            |
+| exec           | No          | No           | No             |
+| exists         | Yes         | Yes          | Yes            |
+| list_dir       | Yes         | Yes          | Yes            |
+| mov            | Yes         | Yes          | Yes            |
+| open_file      | Yes         | Yes          | Yes            |
+| open           | No          | No           | Yes            |
+| pwd            | Yes         | Yes          | Yes            |
+| remove_dir_all | Yes         | Yes          | Yes            |
+| remove_dir     | Yes         | Yes          | Yes            |
+| remove_file    | Yes         | Yes          | Yes            |
+| setstat        | No          | No           | Yes            |
+| stat           | Yes         | Yes          | Yes            |
+| symlink        | No          | No           | Yes            |
 
 ---
 
@@ -236,8 +291,8 @@ just test                  # cargo test --lib, then --doc
 just coverage              # cargo llvm-cov, writes lcov.info
 just fmt                   # dprint fmt (Markdown, Rust, TOML, YAML)
 just fmt_check             # dprint check
-just lint "-- -D warnings" # clippy with all features
-just doc                   # cargo doc --all-features
+just lint "-- -D warnings" # clippy
+just doc                   # cargo doc --no-deps
 just deny                  # cargo deny check
 just scan_secrets          # trufflehog filesystem
 just check                 # the full local quality gate
@@ -248,6 +303,8 @@ and `test`, and is the required gate before opening a pull request. Most
 tests need the Samba container from `tests/docker-compose.yml` running
 locally (`docker compose -f tests/docker-compose.yml up -d --build`) before
 `just test "--no-default-features --features find,with-containers"` will pass.
+Pass `--features smb` (or `find,pavao,smb,with-containers`) to cover the
+Rust-native client; it shares the same container.
 
 See [AGENTS.md](AGENTS.md) for the full contract.
 
@@ -284,6 +341,7 @@ View remotefs' changelog [HERE](CHANGELOG.md)
 remotefs-smb is powered by these aweseome projects:
 
 - [pavao](https://github.com/veeso/pavao)
+- [smb-rs](https://github.com/afiffon/smb-rs)
 
 ---
 

--- a/deny.toml
+++ b/deny.toml
@@ -10,7 +10,12 @@ feature-depth = 1
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
 unmaintained = "all"
-ignore = []
+ignore = [
+  # `smb` -> `sspi` -> `picky` -> `rsa`: RUSTSEC-2023-0071 (Marvin timing
+  # side channel). No patched `rsa` release exists. Revisit on every
+  # `smb`/`sspi` bump.
+  { id = "RUSTSEC-2023-0071", reason = "no fixed rsa release; transitive through sspi/picky" },
+]
 
 [licenses]
 unused-allowed-license = "allow"

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -3,10 +3,10 @@ extern crate log;
 
 use argh::FromArgs;
 use remotefs::RemoteFs;
-#[cfg(target_family = "windows")]
-use remotefs_smb::{SmbCredentials, SmbFs};
 #[cfg(target_family = "unix")]
-use remotefs_smb::{SmbCredentials, SmbFs, SmbOptions};
+use remotefs_smb::{PavaoSmbCredentials, PavaoSmbFs, PavaoSmbOptions};
+#[cfg(target_family = "windows")]
+use remotefs_smb::{WNetSmbCredentials, WNetSmbFs};
 
 #[derive(FromArgs)]
 #[argh(description = "
@@ -74,35 +74,35 @@ fn main() -> anyhow::Result<()> {
 }
 
 #[cfg(target_family = "windows")]
-fn init_client(args: Args) -> SmbFs {
+fn init_client(args: Args) -> WNetSmbFs {
     info!(
         "initializing client with server {} and share {}",
         args.server, args.share
     );
-    let mut credentials = SmbCredentials::new(args.server, args.share);
+    let mut credentials = WNetSmbCredentials::new(args.server, args.share);
     if let Some(username) = args.username {
         credentials = credentials.username(username);
     }
     if let Some(password) = args.password {
         credentials = credentials.password(password);
     }
-    SmbFs::new(credentials)
+    WNetSmbFs::new(credentials)
 }
 
 #[cfg(target_family = "unix")]
-fn init_client(args: Args, password: String) -> anyhow::Result<SmbFs> {
+fn init_client(args: Args, password: String) -> anyhow::Result<PavaoSmbFs> {
     info!(
         "initializing client with server {} and share {}, with username {} and workgroup {}",
         args.server, args.share, args.username, args.workgroup
     );
-    let client = SmbFs::try_new(
-        SmbCredentials::default()
+    let client = PavaoSmbFs::try_new(
+        PavaoSmbCredentials::default()
             .server(args.server)
             .share(args.share)
             .username(args.username)
             .password(password)
             .workgroup(args.workgroup),
-        SmbOptions::default()
+        PavaoSmbOptions::default()
             .one_share_per_server(true)
             .case_sensitive(false),
     )?;

--- a/examples/tree_rs.rs
+++ b/examples/tree_rs.rs
@@ -1,0 +1,76 @@
+#[macro_use]
+extern crate log;
+
+use std::sync::Arc;
+
+use argh::FromArgs;
+use remotefs::RemoteFs;
+use remotefs_smb::{SmbCredentials, SmbFs, SmbOptions};
+use tokio::runtime::Runtime;
+
+#[derive(FromArgs)]
+#[argh(description = "
+where positional can be: [smb://address[:port]]
+
+Lists the share root with the Rust-native SMB client.
+
+Please, report issues to <https://github.com/remotefs-rs/remotefs-rs-smb>
+Please, consider supporting the author <https://ko-fi.com/veeso>")]
+struct Args {
+    #[argh(option, short = 'P', description = "specify password")]
+    password: Option<String>,
+    #[argh(option, short = 'u', description = "specify username")]
+    username: String,
+    #[argh(
+        option,
+        short = 'w',
+        default = r#""WORKGROUP".to_string()"#,
+        description = "specify workgroup"
+    )]
+    workgroup: String,
+    #[argh(option, short = 's', description = "specify share")]
+    share: String,
+    #[argh(positional, description = "smb://address[:port]")]
+    server: String,
+}
+
+fn main() -> anyhow::Result<()> {
+    assert!(env_logger::builder().try_init().is_ok());
+    let args: Args = argh::from_env();
+    let password = match &args.password {
+        Some(password) => password.clone(),
+        None => rpassword::prompt_password("Password: ")?,
+    };
+
+    info!(
+        "initializing client with server {} and share {}, with username {} and workgroup {}",
+        args.server, args.share, args.username, args.workgroup
+    );
+    let runtime = Arc::new(Runtime::new()?);
+    let mut client = SmbFs::try_new(
+        SmbCredentials::default()
+            .server(args.server)
+            .share(args.share)
+            .username(args.username)
+            .password(password)
+            .workgroup(args.workgroup),
+        SmbOptions::default(),
+        &runtime,
+    )?;
+
+    info!("connecting to server...");
+    client.connect()?;
+    info!("client connected");
+
+    let wrkdir = client.pwd()?;
+    info!("listing files at {}", wrkdir.display());
+    for file in client.list_dir(&wrkdir)? {
+        println!("{}", file.name());
+    }
+
+    info!("disconnecting client...");
+    client.disconnect()?;
+    info!("client disconnected");
+
+    Ok(())
+}

--- a/just/code_check.just
+++ b/just/code_check.just
@@ -40,7 +40,7 @@ setup_githooks:
 [group('code-check')]
 check:
   just fmt_check
-  just clippy "-- -D warnings"
-  just doc
+  just clippy "--features smb -- -D warnings"
+  just doc "--features smb"
   just deny
-  just test
+  just test "--features smb"

--- a/src/client.rs
+++ b/src/client.rs
@@ -30,7 +30,19 @@ pub enum SmbDialect {
     Smb311,
 }
 
+#[cfg(any(
+    all(target_family = "unix", feature = "pavao"),
+    feature = "smb",
+    target_family = "windows",
+    test,
+))]
 const AUTO_MIN_DIALECT: SmbDialect = SmbDialect::Smb202;
+#[cfg(any(
+    all(target_family = "unix", feature = "pavao"),
+    feature = "smb",
+    target_family = "windows",
+    test,
+))]
 const AUTO_MAX_DIALECT: SmbDialect = SmbDialect::Smb311;
 
 #[cfg(test)]
@@ -55,16 +67,23 @@ mod test {
     }
 }
 
-// -- unix client
+// -- unix client (pavao / libsmbclient)
 
-#[cfg(target_family = "unix")]
+#[cfg(all(target_family = "unix", feature = "pavao"))]
 mod unix;
-#[cfg(target_family = "unix")]
+#[cfg(all(target_family = "unix", feature = "pavao"))]
 pub use unix::*;
 
-// -- windows client
+// -- windows client (WNet)
 
 #[cfg(target_family = "windows")]
 mod windows;
 #[cfg(target_family = "windows")]
 pub use windows::*;
+
+// -- rust-native client (smb crate)
+
+#[cfg(feature = "smb")]
+mod rust_smb;
+#[cfg(feature = "smb")]
+pub use rust_smb::{SmbCredentials, SmbEncryptionLevel, SmbFs, SmbOptions};

--- a/src/client/rust_smb.rs
+++ b/src/client/rust_smb.rs
@@ -1,0 +1,1358 @@
+//! # Rust-native client
+//!
+//! `RemoteFs` implementation backed by the pure-Rust [`smb`] crate.
+
+mod convert;
+mod credentials;
+mod options;
+
+use std::future::Future;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use convert::{
+    dir_entry_to_file, open_info_to_file, relative_unc_path, smb_error, to_backslash_path, unc_for,
+};
+use credentials::ResolvedCredentials;
+pub use credentials::SmbCredentials;
+use futures_util::StreamExt;
+pub use options::{SmbEncryptionLevel, SmbOptions};
+use remotefs::fs::{File, Metadata, ReadStream, UnixPex, Welcome, WriteStream};
+use remotefs::{RemoteError, RemoteErrorType, RemoteFs, RemoteResult};
+use smb::{
+    Client, ClientConfig, CreateDisposition, CreateOptions, DirAccessMask, Directory,
+    FileAccessMask, FileAttributes, FileCreateArgs, FileDispositionInformation,
+    FileIdBothDirectoryInformation, FileNetworkOpenInformation, FileRenameInformation, GetLen,
+    ReadAt, Resource, ResourceHandle, UncPath, WriteAt,
+};
+use tokio::runtime::Runtime;
+
+use super::{SmbDialect, AUTO_MAX_DIALECT, AUTO_MIN_DIALECT};
+
+/// Chunk size for streaming reads and writes.
+const IO_CHUNK_SIZE: usize = 64 * 1024;
+
+/// SMB file system client built on the pure-Rust [`smb`] crate.
+///
+/// The client is synchronous from the caller's point of view: every
+/// operation runs on the Tokio runtime supplied at construction through
+/// [`Runtime::block_on`]. Consequently:
+///
+/// - the runtime must outlive the client;
+/// - the client must not be driven from a task running on that same
+///   runtime, because `block_on` would panic;
+/// - readers passed to `create_file`/`append_file` are read on the thread
+///   that executes the call.
+///
+/// Only SMB 2.0.2 through 3.1.1 are supported; [`SmbDialect::Nt1`] is
+/// rejected at construction.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::path::Path;
+/// use std::sync::Arc;
+///
+/// use remotefs::RemoteFs;
+/// use remotefs::fs::UnixPex;
+/// use remotefs_smb::{SmbCredentials, SmbFs, SmbOptions};
+/// use tokio::runtime::Runtime;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let runtime = Arc::new(Runtime::new()?);
+/// let mut client = SmbFs::try_new(
+///     SmbCredentials::default()
+///         .server("smb://localhost:3445")
+///         .share("/temp")
+///         .username("test")
+///         .password("test")
+///         .workgroup("pavao"),
+///     SmbOptions::default(),
+///     &runtime,
+/// )?;
+/// client.connect()?;
+/// println!("Wrkdir: {}", client.pwd()?.display());
+/// client.create_dir(Path::new("/cargo"), UnixPex::from(0o755))?;
+/// client.change_dir(Path::new("/cargo"))?;
+/// client.disconnect()?;
+/// # Ok(())
+/// # }
+/// ```
+#[cfg_attr(docsrs, doc(cfg(feature = "smb")))]
+pub struct SmbFs {
+    config: ClientConfig,
+    credentials: ResolvedCredentials,
+    client: Option<Client>,
+    runtime: Arc<Runtime>,
+    wrkdir: PathBuf,
+}
+
+impl std::fmt::Debug for SmbFs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SmbFs")
+            .field("share", &self.credentials.share.to_string())
+            .field("connected", &self.client.is_some())
+            .field("wrkdir", &self.wrkdir)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for SmbFs {
+    fn drop(&mut self) {
+        let Some(client) = self.client.take() else {
+            return;
+        };
+        let close = async move {
+            let _ = client.close().await;
+            drop(client);
+        };
+        if tokio::runtime::Handle::try_current().is_ok() {
+            self.runtime.spawn(close);
+        } else {
+            self.runtime.block_on(close);
+        }
+    }
+}
+
+impl SmbFs {
+    /// Tries to create a client with secure automatic dialect bounds
+    /// (SMB 2.0.2 through 3.1.1).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RemoteErrorType::BadAddress`] if the server or share in
+    /// `credentials` cannot be parsed.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::sync::Arc;
+    ///
+    /// use remotefs_smb::{SmbCredentials, SmbFs, SmbOptions};
+    /// use tokio::runtime::Runtime;
+    ///
+    /// let runtime = Arc::new(Runtime::new()?);
+    /// let _client = SmbFs::try_new(
+    ///     SmbCredentials::default()
+    ///         .server("server.example")
+    ///         .share("documents"),
+    ///     SmbOptions::default(),
+    ///     &runtime,
+    /// )?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn try_new(
+        credentials: SmbCredentials,
+        options: SmbOptions,
+        runtime: &Arc<Runtime>,
+    ) -> RemoteResult<Self> {
+        Self::try_new_with_dialect(
+            credentials,
+            options,
+            AUTO_MIN_DIALECT,
+            AUTO_MAX_DIALECT,
+            runtime,
+        )
+    }
+
+    /// Tries to create a client with inclusive protocol dialect bounds.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RemoteErrorType::BadAddress`] if the bounds are inverted,
+    /// if either bound is [`SmbDialect::Nt1`], or if the credentials cannot
+    /// be parsed.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::sync::Arc;
+    ///
+    /// use remotefs_smb::{SmbCredentials, SmbDialect, SmbFs, SmbOptions};
+    /// use tokio::runtime::Runtime;
+    ///
+    /// let runtime = Arc::new(Runtime::new()?);
+    /// let _client = SmbFs::try_new_with_dialect(
+    ///     SmbCredentials::default()
+    ///         .server("server.example")
+    ///         .share("documents"),
+    ///     SmbOptions::default(),
+    ///     SmbDialect::Smb300,
+    ///     SmbDialect::Smb311,
+    ///     &runtime,
+    /// )?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn try_new_with_dialect(
+        credentials: SmbCredentials,
+        options: SmbOptions,
+        min_dialect: SmbDialect,
+        max_dialect: SmbDialect,
+        runtime: &Arc<Runtime>,
+    ) -> RemoteResult<Self> {
+        let credentials = credentials.resolve()?;
+        let config =
+            options::build_client_config(&options, credentials.port, min_dialect, max_dialect)?;
+        Ok(Self {
+            config,
+            credentials,
+            client: None,
+            runtime: Arc::clone(runtime),
+            wrkdir: PathBuf::from("/"),
+        })
+    }
+
+    /// Returns the inner [`smb::Client`] while connected.
+    pub fn client(&self) -> Option<&Client> {
+        self.client.as_ref()
+    }
+
+    // -- private
+
+    fn is_connected_flag(&self) -> bool {
+        self.client.is_some()
+    }
+
+    fn connected_client(&self) -> RemoteResult<&Client> {
+        self.client
+            .as_ref()
+            .ok_or_else(|| RemoteError::new(RemoteErrorType::NotConnected))
+    }
+
+    fn block_on<F: Future>(&self, future: F) -> F::Output {
+        self.runtime.block_on(future)
+    }
+
+    /// Absolutizes `path` and returns it with the matching UNC path.
+    fn unc(&self, path: &Path) -> (PathBuf, UncPath) {
+        let (absolute, relative) = relative_unc_path(self.wrkdir.as_path(), path);
+        (absolute, unc_for(&self.credentials.share, &relative))
+    }
+
+    async fn open(
+        client: &Client,
+        unc: &UncPath,
+        args: &FileCreateArgs,
+        kind: RemoteErrorType,
+    ) -> RemoteResult<Resource> {
+        client
+            .create_file(unc, args)
+            .await
+            .map_err(|e| smb_error(kind, e))
+    }
+
+    fn handle_of(resource: &Resource) -> Option<&ResourceHandle> {
+        match resource {
+            Resource::File(file) => Some(file.handle()),
+            Resource::Directory(dir) => Some(dir.handle()),
+            Resource::Pipe(pipe) => Some(pipe),
+        }
+    }
+
+    async fn close(handle: &ResourceHandle) -> RemoteResult<()> {
+        handle
+            .close()
+            .await
+            .map_err(|e| smb_error(RemoteErrorType::ProtocolError, e))
+    }
+
+    async fn stat_unc(client: &Client, unc: &UncPath) -> RemoteResult<FileNetworkOpenInformation> {
+        let args = FileCreateArgs::make_open_existing(
+            FileAccessMask::new().with_file_read_attributes(true),
+        );
+        let resource = Self::open(client, unc, &args, RemoteErrorType::StatFailed).await?;
+        let handle = match Self::handle_of(&resource) {
+            Some(handle) => handle,
+            None => {
+                drop(resource);
+                return Err(RemoteError::new_ex(
+                    RemoteErrorType::StatFailed,
+                    "not a file",
+                ));
+            }
+        };
+        let info = handle
+            .query_info::<FileNetworkOpenInformation>()
+            .await
+            .map_err(|e| smb_error(RemoteErrorType::StatFailed, e));
+        Self::close(handle).await.map_err(|e| {
+            RemoteError::new_ex(RemoteErrorType::StatFailed, e.msg.unwrap_or_default())
+        })?;
+        info
+    }
+
+    /// Opens `unc` with delete access and marks it for deletion on close.
+    async fn delete_unc(
+        client: &Client,
+        unc: &UncPath,
+        options: CreateOptions,
+        access: FileAccessMask,
+    ) -> RemoteResult<()> {
+        let args = FileCreateArgs {
+            disposition: CreateDisposition::Open,
+            attributes: FileAttributes::new(),
+            options,
+            desired_access: access,
+        };
+        let resource = Self::open(client, unc, &args, RemoteErrorType::CouldNotRemoveFile).await?;
+        let handle = Self::handle_of(&resource).ok_or_else(|| {
+            RemoteError::new_ex(RemoteErrorType::CouldNotRemoveFile, "not a file")
+        })?;
+        let result = handle
+            .set_info(FileDispositionInformation::default())
+            .await
+            .map_err(|e| smb_error(RemoteErrorType::CouldNotRemoveFile, e));
+        handle
+            .close()
+            .await
+            .map_err(|e| smb_error(RemoteErrorType::CouldNotRemoveFile, e))?;
+        result
+    }
+
+    /// Copies `reader` into `file` starting at `offset`; returns bytes written.
+    async fn write_from(
+        file: &smb::File,
+        mut reader: Box<dyn Read + Send>,
+        mut offset: u64,
+    ) -> RemoteResult<u64> {
+        let mut buffer = vec![0u8; IO_CHUNK_SIZE];
+        let mut written = 0u64;
+        loop {
+            let read = reader
+                .read(&mut buffer)
+                .map_err(|e| RemoteError::new_ex(RemoteErrorType::IoError, e))?;
+            if read == 0 {
+                break;
+            }
+            let mut chunk = &buffer[..read];
+            while !chunk.is_empty() {
+                let n = file
+                    .write_at(chunk, offset)
+                    .await
+                    .map_err(|e| smb_error(RemoteErrorType::IoError, e))?;
+                if n == 0 {
+                    return Err(RemoteError::new_ex(
+                        RemoteErrorType::IoError,
+                        "server accepted zero bytes",
+                    ));
+                }
+                chunk = &chunk[n..];
+                offset += n as u64;
+                written += n as u64;
+            }
+        }
+        Ok(written)
+    }
+
+    /// Copies `file` into `dest`; returns bytes read.
+    async fn read_into(file: &smb::File, mut dest: Box<dyn Write + Send>) -> RemoteResult<u64> {
+        let mut buffer = vec![0u8; IO_CHUNK_SIZE];
+        let mut offset = 0u64;
+        loop {
+            let n = file
+                .read_at(&mut buffer, offset)
+                .await
+                .map_err(|e| smb_error(RemoteErrorType::IoError, e))?;
+            if n == 0 {
+                break;
+            }
+            dest.write_all(&buffer[..n])
+                .map_err(|e| RemoteError::new_ex(RemoteErrorType::IoError, e))?;
+            offset += n as u64;
+        }
+        dest.flush()
+            .map_err(|e| RemoteError::new_ex(RemoteErrorType::IoError, e))?;
+        Ok(offset)
+    }
+}
+
+impl RemoteFs for SmbFs {
+    fn connect(&mut self) -> RemoteResult<Welcome> {
+        if self.client.is_some() {
+            return Err(RemoteError::new(RemoteErrorType::AlreadyConnected));
+        }
+        let config = self.config.clone();
+        let credentials = self.credentials.clone();
+        debug!("connecting to {}", credentials.share);
+        let client = self.block_on(async move {
+            let client = Client::new(config);
+            client
+                .share_connect(
+                    &credentials.share,
+                    &credentials.logon_name,
+                    credentials.password,
+                )
+                .await
+                .map_err(|e| smb_error(RemoteErrorType::ConnectionError, e))?;
+            Ok::<Client, RemoteError>(client)
+        })?;
+        self.client = Some(client);
+        self.wrkdir = PathBuf::from("/");
+        Ok(Welcome::default())
+    }
+
+    fn disconnect(&mut self) -> RemoteResult<()> {
+        let client = self
+            .client
+            .take()
+            .ok_or_else(|| RemoteError::new(RemoteErrorType::NotConnected))?;
+        debug!("disconnecting from {}", self.credentials.share);
+        self.block_on(async move {
+            let result = client
+                .close()
+                .await
+                .map_err(|e| smb_error(RemoteErrorType::ConnectionError, e));
+            drop(client);
+            result
+        })
+    }
+
+    fn is_connected(&mut self) -> bool {
+        self.is_connected_flag()
+    }
+
+    fn pwd(&mut self) -> RemoteResult<PathBuf> {
+        self.connected_client().map(|_| self.wrkdir.clone())
+    }
+
+    fn change_dir(&mut self, dir: &Path) -> RemoteResult<PathBuf> {
+        self.connected_client()?;
+        let (dir, _) = self.unc(dir);
+        trace!("changing directory to {}", dir.display());
+        if self.stat(dir.as_path())?.is_dir() {
+            self.wrkdir = dir;
+            debug!("new working directory: {}", self.wrkdir.display());
+            Ok(self.wrkdir.clone())
+        } else {
+            error!("cannot enter directory {}. Not a directory", dir.display());
+            Err(RemoteError::new_ex(
+                RemoteErrorType::BadFile,
+                "not a directory",
+            ))
+        }
+    }
+
+    fn list_dir(&mut self, path: &Path) -> RemoteResult<Vec<File>> {
+        let client = self.connected_client()?;
+        let (absolute, unc) = self.unc(path);
+        trace!("listing files at {}", absolute.display());
+        self.block_on(async {
+            let args = FileCreateArgs::make_open_existing(
+                DirAccessMask::new()
+                    .with_list_directory(true)
+                    .with_synchronize(true)
+                    .into(),
+            );
+            let resource = Self::open(client, &unc, &args, RemoteErrorType::StatFailed).await?;
+            let dir = match resource {
+                Resource::Directory(dir) => Arc::new(dir),
+                other => {
+                    if let Some(handle) = Self::handle_of(&other) {
+                        Self::close(handle).await?;
+                    }
+                    return Err(RemoteError::new_ex(
+                        RemoteErrorType::StatFailed,
+                        "not a directory",
+                    ));
+                }
+            };
+            let entries = async {
+                let mut stream = Directory::query::<FileIdBothDirectoryInformation>(&dir, "*")
+                    .await
+                    .map_err(|e| smb_error(RemoteErrorType::StatFailed, e))?;
+                let mut entries = Vec::new();
+                while let Some(entry) = stream.next().await {
+                    let entry = entry.map_err(|e| smb_error(RemoteErrorType::StatFailed, e))?;
+                    let name = entry.file_name.to_string();
+                    if name == "." || name == ".." {
+                        continue;
+                    }
+                    entries.push(dir_entry_to_file(absolute.as_path(), &entry));
+                }
+                Ok::<Vec<File>, RemoteError>(entries)
+            }
+            .await;
+            let close_result = Self::close(dir.handle()).await.map_err(|e| {
+                RemoteError::new_ex(RemoteErrorType::StatFailed, e.msg.unwrap_or_default())
+            });
+            drop(dir);
+            match (entries, close_result) {
+                (Err(err), _) => Err(err),
+                (Ok(_), Err(err)) => Err(err),
+                (Ok(entries), Ok(())) => Ok(entries),
+            }
+        })
+    }
+
+    fn stat(&mut self, path: &Path) -> RemoteResult<File> {
+        let client = self.connected_client()?;
+        let (absolute, unc) = self.unc(path);
+        trace!("get stat for {}", absolute.display());
+        let info = self.block_on(Self::stat_unc(client, &unc))?;
+        Ok(open_info_to_file(absolute, &info))
+    }
+
+    fn setstat(&mut self, _path: &Path, _metadata: Metadata) -> RemoteResult<()> {
+        Err(RemoteError::new(RemoteErrorType::UnsupportedFeature))
+    }
+
+    fn exists(&mut self, path: &Path) -> RemoteResult<bool> {
+        trace!("checking if {} exists...", path.display());
+        match self.stat(path) {
+            Ok(_) => Ok(true),
+            Err(RemoteError {
+                kind: RemoteErrorType::StatFailed,
+                ..
+            }) => Ok(false),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn remove_file(&mut self, path: &Path) -> RemoteResult<()> {
+        let client = self.connected_client()?;
+        let (absolute, unc) = self.unc(path);
+        trace!("removing file {}", absolute.display());
+        self.block_on(Self::delete_unc(
+            client,
+            &unc,
+            CreateOptions::new().with_non_directory_file(true),
+            FileAccessMask::new().with_delete(true),
+        ))
+    }
+
+    fn remove_dir(&mut self, path: &Path) -> RemoteResult<()> {
+        let client = self.connected_client()?;
+        let (absolute, unc) = self.unc(path);
+        trace!("removing directory at {}", absolute.display());
+        self.block_on(Self::delete_unc(
+            client,
+            &unc,
+            CreateOptions::new().with_directory_file(true),
+            DirAccessMask::new().with_delete(true).into(),
+        ))
+    }
+
+    fn create_dir(&mut self, path: &Path, _mode: UnixPex) -> RemoteResult<()> {
+        self.connected_client()?;
+        if self.exists(path)? {
+            return Err(RemoteError::new(RemoteErrorType::DirectoryAlreadyExists));
+        }
+        let client = self.connected_client()?;
+        let (absolute, unc) = self.unc(path);
+        trace!("making directory at {}", absolute.display());
+        self.block_on(async {
+            let args = FileCreateArgs::make_create_new(
+                FileAttributes::new().with_directory(true),
+                CreateOptions::new().with_directory_file(true),
+            );
+            let resource =
+                Self::open(client, &unc, &args, RemoteErrorType::FileCreateDenied).await?;
+            match Self::handle_of(&resource) {
+                Some(handle) => Self::close(handle).await,
+                None => Ok(()),
+            }
+        })
+    }
+
+    fn symlink(&mut self, _path: &Path, _target: &Path) -> RemoteResult<()> {
+        Err(RemoteError::new(RemoteErrorType::UnsupportedFeature))
+    }
+
+    fn copy(&mut self, _src: &Path, _dest: &Path) -> RemoteResult<()> {
+        Err(RemoteError::new(RemoteErrorType::UnsupportedFeature))
+    }
+
+    fn mov(&mut self, src: &Path, dest: &Path) -> RemoteResult<()> {
+        let client = self.connected_client()?;
+        let (src_abs, src_unc) = self.unc(src);
+        let (dest_abs, dest_rel) = relative_unc_path(self.wrkdir.as_path(), dest);
+        trace!("moving {} to {}", src_abs.display(), dest_abs.display());
+        self.block_on(async {
+            let args = FileCreateArgs::make_open_existing(FileAccessMask::new().with_delete(true));
+            let resource =
+                Self::open(client, &src_unc, &args, RemoteErrorType::ProtocolError).await?;
+            let handle = Self::handle_of(&resource)
+                .ok_or_else(|| RemoteError::new_ex(RemoteErrorType::ProtocolError, "not a file"))?;
+            let result = handle
+                .set_info(FileRenameInformation {
+                    replace_if_exists: false.into(),
+                    root_directory: 0,
+                    file_name: to_backslash_path(dest_rel.trim_matches(['/', '\\'])).into(),
+                })
+                .await
+                .map_err(|e| smb_error(RemoteErrorType::ProtocolError, e));
+            Self::close(handle).await?;
+            result
+        })
+    }
+
+    fn exec(&mut self, _cmd: &str) -> RemoteResult<(u32, String)> {
+        Err(RemoteError::new(RemoteErrorType::UnsupportedFeature))
+    }
+
+    fn append_file(
+        &mut self,
+        path: &Path,
+        _metadata: &Metadata,
+        reader: Box<dyn Read + Send>,
+    ) -> RemoteResult<u64> {
+        let client = self.connected_client()?;
+        let (absolute, unc) = self.unc(path);
+        trace!("opening file at {} for append", absolute.display());
+        let args = FileCreateArgs {
+            disposition: CreateDisposition::OpenIf,
+            attributes: FileAttributes::new(),
+            options: CreateOptions::new().with_non_directory_file(true),
+            desired_access: FileAccessMask::new()
+                .with_generic_read(true)
+                .with_generic_write(true),
+        };
+        self.block_on(async {
+            let resource =
+                Self::open(client, &unc, &args, RemoteErrorType::CouldNotOpenFile).await?;
+            let file = match resource {
+                Resource::File(file) => file,
+                other => {
+                    if let Some(handle) = Self::handle_of(&other) {
+                        Self::close(handle).await?;
+                    }
+                    return Err(RemoteError::new_ex(
+                        RemoteErrorType::CouldNotOpenFile,
+                        "not a regular file",
+                    ));
+                }
+            };
+            let result = async {
+                let offset = file
+                    .get_len()
+                    .await
+                    .map_err(|e| smb_error(RemoteErrorType::IoError, e))?;
+                Self::write_from(&file, reader, offset).await
+            }
+            .await;
+            Self::close(&file).await?;
+            result
+        })
+    }
+
+    fn create_file(
+        &mut self,
+        path: &Path,
+        _metadata: &Metadata,
+        reader: Box<dyn Read + Send>,
+    ) -> RemoteResult<u64> {
+        let client = self.connected_client()?;
+        let (absolute, unc) = self.unc(path);
+        trace!("creating file at {}", absolute.display());
+        let args = FileCreateArgs::make_overwrite(
+            FileAttributes::new(),
+            CreateOptions::new().with_non_directory_file(true),
+        );
+        self.block_on(async {
+            let resource =
+                Self::open(client, &unc, &args, RemoteErrorType::CouldNotOpenFile).await?;
+            let file = match resource {
+                Resource::File(file) => file,
+                other => {
+                    if let Some(handle) = Self::handle_of(&other) {
+                        Self::close(handle).await?;
+                    }
+                    return Err(RemoteError::new_ex(
+                        RemoteErrorType::CouldNotOpenFile,
+                        "not a regular file",
+                    ));
+                }
+            };
+            let result = Self::write_from(&file, reader, 0).await;
+            Self::close(&file).await?;
+            result
+        })
+    }
+
+    fn open_file(&mut self, path: &Path, dest: Box<dyn Write + Send>) -> RemoteResult<u64> {
+        let client = self.connected_client()?;
+        let (absolute, unc) = self.unc(path);
+        trace!("opening file at {} for read", absolute.display());
+        let args =
+            FileCreateArgs::make_open_existing(FileAccessMask::new().with_generic_read(true));
+        self.block_on(async {
+            let resource =
+                Self::open(client, &unc, &args, RemoteErrorType::CouldNotOpenFile).await?;
+            let file = match resource {
+                Resource::File(file) => file,
+                other => {
+                    if let Some(handle) = Self::handle_of(&other) {
+                        Self::close(handle).await?;
+                    }
+                    return Err(RemoteError::new_ex(
+                        RemoteErrorType::CouldNotOpenFile,
+                        "not a regular file",
+                    ));
+                }
+            };
+            let result = Self::read_into(&file, dest).await;
+            Self::close(&file).await?;
+            result
+        })
+    }
+
+    fn append(&mut self, _path: &Path, _metadata: &Metadata) -> RemoteResult<WriteStream> {
+        Err(RemoteError::new(RemoteErrorType::UnsupportedFeature))
+    }
+
+    fn create(&mut self, _path: &Path, _metadata: &Metadata) -> RemoteResult<WriteStream> {
+        Err(RemoteError::new(RemoteErrorType::UnsupportedFeature))
+    }
+
+    fn open(&mut self, _path: &Path) -> RemoteResult<ReadStream> {
+        Err(RemoteError::new(RemoteErrorType::UnsupportedFeature))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[cfg(feature = "with-containers")]
+    use std::io::Cursor;
+    use std::sync::Arc;
+    #[cfg(feature = "with-containers")]
+    use std::time::Duration;
+
+    use pretty_assertions::assert_eq;
+    #[cfg(feature = "with-containers")]
+    use serial_test::serial;
+    use tokio::runtime::Runtime;
+
+    use super::*;
+
+    #[test]
+    fn should_reject_inverted_dialect_bounds() {
+        let runtime = Arc::new(Runtime::new().unwrap());
+        let result = SmbFs::try_new_with_dialect(
+            test_credentials(),
+            SmbOptions::default(),
+            SmbDialect::Smb311,
+            SmbDialect::Smb202,
+            &runtime,
+        );
+        assert_eq!(
+            result.expect_err("inverted bounds must fail").kind,
+            RemoteErrorType::BadAddress,
+        );
+    }
+
+    #[test]
+    fn should_reject_nt1_dialect() {
+        let runtime = Arc::new(Runtime::new().unwrap());
+        let result = SmbFs::try_new_with_dialect(
+            test_credentials(),
+            SmbOptions::default(),
+            SmbDialect::Nt1,
+            SmbDialect::Smb311,
+            &runtime,
+        );
+        assert_eq!(result.err().unwrap().kind, RemoteErrorType::BadAddress);
+    }
+
+    #[test]
+    fn should_default_to_secure_auto_dialect_bounds() {
+        let runtime = Arc::new(Runtime::new().unwrap());
+        let client = SmbFs::try_new(test_credentials(), SmbOptions::default(), &runtime).unwrap();
+        assert_eq!(
+            client.config.connection.min_dialect,
+            Some(smb::Dialect::Smb0202)
+        );
+        assert_eq!(
+            client.config.connection.max_dialect,
+            Some(smb::Dialect::Smb0311)
+        );
+        assert!(!client.is_connected_flag());
+        assert!(client.client().is_none());
+    }
+
+    #[test]
+    fn should_reject_bad_credentials_at_construction() {
+        let runtime = Arc::new(Runtime::new().unwrap());
+        let result = SmbFs::try_new(
+            SmbCredentials::default().server("smb://"),
+            SmbOptions::default(),
+            &runtime,
+        );
+        assert_eq!(result.err().unwrap().kind, RemoteErrorType::BadAddress);
+    }
+
+    #[test]
+    fn should_fail_when_not_connected() {
+        let runtime = Arc::new(Runtime::new().unwrap());
+        let mut client =
+            SmbFs::try_new(test_credentials(), SmbOptions::default(), &runtime).unwrap();
+        assert_eq!(
+            client.pwd().unwrap_err().kind,
+            RemoteErrorType::NotConnected
+        );
+        assert_eq!(
+            client.stat(Path::new("/")).unwrap_err().kind,
+            RemoteErrorType::NotConnected
+        );
+        assert!(!client.is_connected());
+    }
+
+    fn is_send<T: Send>(_send: T) {}
+
+    fn is_sync<T: Sync>(_sync: T) {}
+
+    #[test]
+    fn test_should_be_sync() {
+        let runtime = Arc::new(Runtime::new().unwrap());
+        let client = SmbFs::try_new(test_credentials(), SmbOptions::default(), &runtime).unwrap();
+        is_sync(client);
+    }
+
+    #[test]
+    fn test_should_be_send() {
+        let runtime = Arc::new(Runtime::new().unwrap());
+        let client = SmbFs::try_new(test_credentials(), SmbOptions::default(), &runtime).unwrap();
+        is_send(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_connect_and_disconnect() {
+        crate::mock::logger();
+        let mut client = init_client();
+        assert!(client.is_connected());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_change_directory() {
+        crate::mock::logger();
+        let mut client = init_client();
+        let pwd = client.pwd().ok().unwrap();
+        assert!(client.change_dir(Path::new("/cargo-test")).is_ok());
+        assert!(client.change_dir(pwd.as_path()).is_ok());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_not_change_directory() {
+        crate::mock::logger();
+        let mut client = init_client();
+        assert!(client
+            .change_dir(Path::new("/tmp/sdfghjuireghiuergh/useghiyuwegh"))
+            .is_err());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_print_working_directory() {
+        crate::mock::logger();
+        let mut client = init_client();
+        assert!(client.pwd().is_ok());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_stat_directory() {
+        crate::mock::logger();
+        let mut client = init_client();
+        let entry = client.stat(Path::new("/cargo-test")).ok().unwrap();
+        assert!(entry.is_dir());
+        assert_eq!(entry.path(), Path::new("/cargo-test"));
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_not_stat_file() {
+        crate::mock::logger();
+        let mut client = init_client();
+        let p = Path::new("a.sh");
+        assert!(client.stat(p).is_err());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_tell_whether_directory_exists() {
+        crate::mock::logger();
+        let mut client = init_client();
+        assert!(client.exists(Path::new("/cargo-test/")).ok().unwrap());
+        assert!(!client.exists(Path::new("/cargo-test/b.txt")).ok().unwrap());
+        assert!(!client.exists(Path::new("/tmp/ppppp/bhhrhu")).ok().unwrap());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_list_empty_dir() {
+        crate::mock::logger();
+        let mut client = init_client();
+        let files = client.list_dir(Path::new("/cargo-test/")).ok().unwrap();
+        assert!(files.is_empty());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_not_list_dir() {
+        crate::mock::logger();
+        let mut client = init_client();
+        assert!(client.list_dir(Path::new("/tmp/auhhfh/hfhjfhf/")).is_err());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_append_to_file() {
+        crate::mock::logger();
+        let mut client = init_client();
+        let p = Path::new("/cargo-test/a.txt");
+        let file_data = "test data\n";
+        let reader = Cursor::new(file_data.as_bytes());
+        assert_eq!(
+            client
+                .create_file(p, &Metadata::default().size(10), Box::new(reader))
+                .ok()
+                .unwrap(),
+            10
+        );
+        assert_eq!(client.stat(p).ok().unwrap().metadata().size, 10);
+        let file_data = "Hello, world!\n";
+        let reader = Cursor::new(file_data.as_bytes());
+        assert_eq!(
+            client
+                .append_file(p, &Metadata::default().size(14), Box::new(reader))
+                .ok()
+                .unwrap(),
+            14
+        );
+        assert_eq!(client.stat(p).ok().unwrap().metadata().size, 24);
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_not_append_to_file() {
+        crate::mock::logger();
+        let mut client = init_client();
+        let p = Path::new("/tmp/aaaaaaa/hbbbbb/a.txt");
+        let file_data = "Hello, world!\n";
+        let reader = Cursor::new(file_data.as_bytes());
+        assert!(client
+            .append_file(p, &Metadata::default(), Box::new(reader))
+            .is_err());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_not_copy_file() {
+        crate::mock::logger();
+        let mut client = init_client();
+        let p = Path::new("a.txt");
+        let file_data = "test data\n";
+        let reader = Cursor::new(file_data.as_bytes());
+        assert!(client
+            .create_file(p, &Metadata::default(), Box::new(reader))
+            .is_ok());
+        assert!(client.copy(p, Path::new("aaa/bbbb/ccc/b.txt")).is_err());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_create_directory() {
+        crate::mock::logger();
+        let mut client = init_client();
+        assert!(client
+            .create_dir(Path::new("/cargo-test/mydir"), UnixPex::from(0o755))
+            .is_ok());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_not_create_directory_cause_already_exists() {
+        crate::mock::logger();
+        let mut client = init_client();
+        assert!(client
+            .create_dir(Path::new("/cargo-test/mydir"), UnixPex::from(0o755))
+            .is_ok());
+        assert_eq!(
+            client
+                .create_dir(Path::new("/cargo-test/mydir"), UnixPex::from(0o755))
+                .err()
+                .unwrap()
+                .kind,
+            RemoteErrorType::DirectoryAlreadyExists
+        );
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_not_create_directory() {
+        crate::mock::logger();
+        let mut client = init_client();
+        assert!(client
+            .create_dir(
+                Path::new("/tmp/werfgjwerughjwurih/iwerjghiwgui"),
+                UnixPex::from(0o755)
+            )
+            .is_err());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_create_file() {
+        crate::mock::logger();
+        let mut client = init_client();
+        let p = Path::new("/cargo-test/a.txt");
+        let file_data = "test data\n";
+        let reader = Cursor::new(file_data.as_bytes());
+        assert_eq!(
+            client
+                .create_file(p, &Metadata::default().size(10), Box::new(reader))
+                .ok()
+                .unwrap(),
+            10
+        );
+        assert_eq!(client.stat(p).ok().unwrap().metadata().size, 10);
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_not_create_file() {
+        crate::mock::logger();
+        let mut client = init_client();
+        let p = Path::new("/tmp/ahsufhauiefhuiashf/hfhfhfhf");
+        let file_data = "test data\n";
+        let reader = Cursor::new(file_data.as_bytes());
+        assert!(client
+            .create_file(p, &Metadata::default(), Box::new(reader))
+            .is_err());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_not_exec_command() {
+        crate::mock::logger();
+        let mut client = init_client();
+        assert!(client.exec("echo 5").is_err());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_tell_whether_file_exists() {
+        crate::mock::logger();
+        let mut client = init_client();
+        let p = Path::new("/cargo-test/a.txt");
+        let file_data = "test data\n";
+        let reader = Cursor::new(file_data.as_bytes());
+        assert!(client
+            .create_file(p, &Metadata::default(), Box::new(reader))
+            .is_ok());
+        assert!(client.exists(p).ok().unwrap());
+        assert!(!client.exists(Path::new("/cargo-test/b.txt")).ok().unwrap());
+        assert!(!client.exists(Path::new("/tmp/ppppp/bhhrhu")).ok().unwrap());
+        assert!(client.exists(Path::new("/cargo-test/")).ok().unwrap());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_list_dir() {
+        crate::mock::logger();
+        let mut client = init_client();
+        let wrkdir = client.pwd().ok().unwrap();
+        let p = Path::new("/cargo-test/a.txt");
+        let file_data = "test data\n";
+        let reader = Cursor::new(file_data.as_bytes());
+        assert_eq!(
+            client
+                .append_file(p, &Metadata::default().size(10), Box::new(reader))
+                .unwrap(),
+            10
+        );
+        let file = client
+            .list_dir(Path::new("/cargo-test/"))
+            .ok()
+            .unwrap()
+            .first()
+            .unwrap()
+            .clone();
+        assert_eq!(file.name().as_str(), "a.txt");
+        let mut expected_path = wrkdir;
+        expected_path.push(p);
+        assert_eq!(file.path.as_path(), expected_path.as_path());
+        assert_eq!(file.extension().as_deref().unwrap(), "txt");
+        assert_eq!(file.metadata.size, 10);
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_move_file() {
+        crate::mock::logger();
+        let mut client = init_client();
+        let p = Path::new("/cargo-test/a.txt");
+        let file_data = "test data\n";
+        let reader = Cursor::new(file_data.as_bytes());
+        assert!(client
+            .create_file(p, &Metadata::default(), Box::new(reader))
+            .is_ok());
+        let dest = Path::new("/cargo-test/b.txt");
+        assert!(client.mov(p, dest).is_ok());
+        assert!(!client.exists(p).ok().unwrap());
+        assert!(client.exists(dest).ok().unwrap());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_not_move_file() {
+        crate::mock::logger();
+        let mut client = init_client();
+        let p = Path::new("a.txt");
+        let file_data = "test data\n";
+        let reader = Cursor::new(file_data.as_bytes());
+        assert!(client
+            .create_file(p, &Metadata::default(), Box::new(reader))
+            .is_ok());
+        let dest = Path::new("/tmp/wuefhiwuerfh/whjhh/b.txt");
+        assert!(client.mov(p, dest).is_err());
+        assert!(client.mov(dest, p).is_err());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_open_file() {
+        crate::mock::logger();
+        let mut client = init_client();
+        let p = Path::new("/cargo-test/a.txt");
+        let file_data = "test data\n";
+        let reader = Cursor::new(file_data.as_bytes());
+        assert!(client
+            .create_file(p, &Metadata::default().size(10), Box::new(reader))
+            .is_ok());
+        let buffer: Box<dyn Write + Send> = Box::new(Vec::with_capacity(512));
+        assert_eq!(client.open_file(p, buffer).ok().unwrap(), 10);
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_not_open_file() {
+        crate::mock::logger();
+        let mut client = init_client();
+        let buffer: Box<dyn Write + Send> = Box::new(Vec::with_capacity(512));
+        assert!(client
+            .open_file(Path::new("/tmp/aashafb/hhh"), buffer)
+            .is_err());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_remove_dir_all() {
+        crate::mock::logger();
+        let mut client = init_client();
+        let dir_path = Path::new("/cargo-test/test");
+        assert!(client.create_dir(dir_path, UnixPex::from(0o775)).is_ok());
+        let file_path = Path::new("/cargo-test/test/a.txt");
+        let file_data = "test data\n";
+        let reader = Cursor::new(file_data.as_bytes());
+        assert!(client
+            .create_file(file_path, &Metadata::default(), Box::new(reader))
+            .is_ok());
+        assert!(client.remove_dir_all(dir_path).is_ok());
+        assert!(!client.exists(dir_path).ok().unwrap());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_not_remove_dir_all() {
+        crate::mock::logger();
+        let mut client = init_client();
+        assert!(client
+            .remove_dir_all(Path::new("/tmp/aaaaaa/asuhi"))
+            .is_err());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_remove_dir() {
+        crate::mock::logger();
+        let mut client = init_client();
+        let dir_path = Path::new("/cargo-test/test");
+        assert!(client.create_dir(dir_path, UnixPex::from(0o775)).is_ok());
+        assert!(client.remove_dir(dir_path).is_ok());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_not_remove_dir() {
+        crate::mock::logger();
+        let mut client = init_client();
+        let dir_path = Path::new("/cargo-test/test");
+        assert!(client.create_dir(dir_path, UnixPex::from(0o775)).is_ok());
+        let file_path = Path::new("/cargo-test/test/a.txt");
+        let file_data = "test data\n";
+        let reader = Cursor::new(file_data.as_bytes());
+        assert!(client
+            .create_file(file_path, &Metadata::default(), Box::new(reader))
+            .is_ok());
+        assert!(client.remove_dir(dir_path).is_err());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_remove_file() {
+        crate::mock::logger();
+        let mut client = init_client();
+        let p = Path::new("/cargo-test/a.txt");
+        let file_data = "test data\n";
+        let reader = Cursor::new(file_data.as_bytes());
+        assert!(client
+            .create_file(p, &Metadata::default(), Box::new(reader))
+            .is_ok());
+        assert!(client.remove_file(p).is_ok());
+        assert!(!client.exists(p).ok().unwrap());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_not_setstat_file() {
+        crate::mock::logger();
+        let mut client = init_client();
+        let p = Path::new("bbbbb/cccc/a.sh");
+        assert!(client
+            .setstat(
+                p,
+                Metadata {
+                    accessed: None,
+                    created: None,
+                    file_type: remotefs::fs::FileType::File,
+                    gid: Some(1),
+                    mode: Some(UnixPex::from(0o755)),
+                    modified: None,
+                    size: 7,
+                    symlink: None,
+                    uid: Some(1),
+                }
+            )
+            .is_err());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_stat_file() {
+        crate::mock::logger();
+        let mut client = init_client();
+        let p = Path::new("/cargo-test/a.sh");
+        let file_data = "echo 5\n";
+        let reader = Cursor::new(file_data.as_bytes());
+        assert!(client
+            .create_file(p, &Metadata::default().size(7), Box::new(reader))
+            .is_ok());
+        let entry = client.stat(p).ok().unwrap();
+        assert_eq!(entry.name(), "a.sh");
+        let mut expected_path = client.pwd().ok().unwrap();
+        expected_path.push("/cargo-test/a.sh");
+        assert_eq!(entry.path(), expected_path.as_path());
+        let meta = entry.metadata();
+        assert_eq!(meta.size, 7);
+        assert!(meta.modified.is_some());
+        finalize_client(client);
+    }
+
+    #[test]
+    #[cfg(feature = "with-containers")]
+    #[serial]
+    fn should_not_make_symlink() {
+        crate::mock::logger();
+        let mut client = init_client();
+        let p = Path::new("/cargo-test/a.sh");
+        let symlink = Path::new("/cargo-test/b.sh");
+        assert!(client.symlink(symlink, p).is_err());
+        finalize_client(client);
+    }
+
+    fn test_credentials() -> SmbCredentials {
+        SmbCredentials::default()
+            .server("smb://localhost:3445")
+            .share("/temp")
+            .username("test")
+            .password("test")
+            .workgroup("pavao")
+    }
+
+    #[cfg(feature = "with-containers")]
+    fn init_client() -> SmbFs {
+        let runtime = Arc::new(Runtime::new().unwrap());
+        let mut client =
+            SmbFs::try_new(test_credentials(), SmbOptions::default(), &runtime).unwrap();
+        assert!(client.connect().is_ok());
+        // Make the test directory over SMB instead of on the host filesystem.
+        let _ = client.remove_dir_all(Path::new("/cargo-test"));
+        client
+            .create_dir(Path::new("/cargo-test"), UnixPex::from(0o755))
+            .unwrap();
+        client
+    }
+
+    #[cfg(feature = "with-containers")]
+    fn finalize_client(mut client: SmbFs) {
+        let _ = client.remove_dir_all(Path::new("/cargo-test"));
+        assert!(client.disconnect().is_ok());
+        std::thread::sleep(Duration::from_secs(1));
+        drop(client);
+    }
+}

--- a/src/client/rust_smb/convert.rs
+++ b/src/client/rust_smb/convert.rs
@@ -1,0 +1,240 @@
+//! Conversions between remotefs types and `smb` crate types.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use remotefs::fs::{File, FileType, Metadata, UnixPex};
+use remotefs::{RemoteError, RemoteErrorType};
+use smb::binrw_util::prelude::FileTime;
+use smb::{FileAttributes, FileIdBothDirectoryInformation, FileNetworkOpenInformation, UncPath};
+
+use crate::utils::path as path_utils;
+
+/// Seconds between 1601-01-01 (FILETIME epoch) and 1970-01-01 (Unix epoch).
+const FILETIME_UNIX_OFFSET_SECS: u64 = 11_644_473_600;
+
+/// Absolutizes `path` against `wrkdir` and returns it together with the
+/// share-relative name: `/`-separated, no leading or trailing slash, empty
+/// for the share root.
+pub(super) fn relative_unc_path(wrkdir: &Path, path: &Path) -> (PathBuf, String) {
+    let absolute = path_utils::absolutize(wrkdir, path);
+    let relative = absolute
+        .to_string_lossy()
+        .trim_matches(['/', '\\'])
+        .replace('\\', "/");
+    (absolute, relative)
+}
+
+/// Builds the UNC path of `relative` under `share`.
+pub(super) fn unc_for(share: &UncPath, relative: &str) -> UncPath {
+    if relative.is_empty() {
+        share.clone()
+    } else {
+        share.clone().with_path(&to_backslash_path(relative))
+    }
+}
+
+/// Converts a `/`-separated relative path into the `\`-separated form used
+/// by `FileRenameInformation`.
+pub(super) fn to_backslash_path(relative: &str) -> String {
+    relative.replace('/', "\\")
+}
+
+/// Converts a FILETIME into a `SystemTime`; zero means "unset".
+pub(super) fn filetime_to_system_time(time: FileTime) -> Option<SystemTime> {
+    if time.is_zero() {
+        return None;
+    }
+    time.since_epoch()
+        .checked_sub(Duration::from_secs(FILETIME_UNIX_OFFSET_SECS))
+        .map(|since_unix| UNIX_EPOCH + since_unix)
+}
+
+/// SMB2 carries no POSIX mode: synthesize one from the attributes.
+pub(super) fn mode_for(attributes: FileAttributes) -> UnixPex {
+    match (attributes.directory(), attributes.readonly()) {
+        (true, false) => UnixPex::from(0o755),
+        (true, true) => UnixPex::from(0o555),
+        (false, false) => UnixPex::from(0o644),
+        (false, true) => UnixPex::from(0o444),
+    }
+}
+
+pub(super) fn file_type_for(attributes: FileAttributes) -> FileType {
+    if attributes.directory() {
+        FileType::Directory
+    } else if attributes.reparse_point() {
+        FileType::Symlink
+    } else {
+        FileType::File
+    }
+}
+
+fn metadata_for(
+    attributes: FileAttributes,
+    size: u64,
+    created: FileTime,
+    modified: FileTime,
+    accessed: FileTime,
+) -> Metadata {
+    let mut metadata = Metadata::default()
+        .file_type(file_type_for(attributes))
+        .mode(mode_for(attributes))
+        .size(size);
+    if let Some(created) = filetime_to_system_time(created) {
+        metadata = metadata.created(created);
+    }
+    if let Some(modified) = filetime_to_system_time(modified) {
+        metadata = metadata.modified(modified);
+    }
+    if let Some(accessed) = filetime_to_system_time(accessed) {
+        metadata = metadata.accessed(accessed);
+    }
+    metadata
+}
+
+/// Builds a remotefs `File` from a `stat`-style query.
+pub(super) fn open_info_to_file(path: PathBuf, info: &FileNetworkOpenInformation) -> File {
+    File {
+        path,
+        metadata: metadata_for(
+            info.file_attributes,
+            info.end_of_file,
+            info.creation_time,
+            info.last_write_time,
+            info.last_access_time,
+        ),
+    }
+}
+
+/// Builds a remotefs `File` from a directory listing entry.
+pub(super) fn dir_entry_to_file(parent: &Path, entry: &FileIdBothDirectoryInformation) -> File {
+    let mut path = parent.to_path_buf();
+    path.push(entry.file_name.to_string());
+    File {
+        path,
+        metadata: metadata_for(
+            entry.file_attributes,
+            entry.end_of_file,
+            entry.creation_time,
+            entry.last_write_time,
+            entry.last_access_time,
+        ),
+    }
+}
+
+/// Wraps an `smb` error into a `RemoteError` of the given kind.
+pub(super) fn smb_error(kind: RemoteErrorType, error: smb::Error) -> RemoteError {
+    RemoteError::new_ex(kind, error)
+}
+
+#[cfg(test)]
+mod test {
+    use std::path::{Path, PathBuf};
+    use std::str::FromStr;
+    use std::time::{Duration, UNIX_EPOCH};
+
+    use pretty_assertions::assert_eq;
+    use remotefs::fs::{FileType, UnixPex};
+    use smb::binrw_util::prelude::FileTime;
+    use smb::{FileAttributes, FileNetworkOpenInformation, UncPath};
+
+    use super::*;
+
+    #[test]
+    fn should_build_relative_unc_paths() {
+        let wrkdir = Path::new("/");
+        assert_eq!(
+            relative_unc_path(wrkdir, Path::new("/cargo-test/a.txt")),
+            (
+                PathBuf::from("/cargo-test/a.txt"),
+                "cargo-test/a.txt".to_string()
+            )
+        );
+        assert_eq!(
+            relative_unc_path(wrkdir, Path::new("/cargo-test/")),
+            (PathBuf::from("/cargo-test/"), "cargo-test".to_string())
+        );
+        assert_eq!(
+            relative_unc_path(wrkdir, Path::new("/")),
+            (PathBuf::from("/"), String::new())
+        );
+        assert_eq!(
+            relative_unc_path(Path::new("/cargo-test"), Path::new("a.txt")),
+            (
+                PathBuf::from("/cargo-test/a.txt"),
+                "cargo-test/a.txt".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn should_build_unc_from_relative() {
+        let share = UncPath::from_str(r"\\localhost\temp").unwrap();
+        assert_eq!(unc_for(&share, "").to_string(), r"\\localhost\temp");
+        assert_eq!(
+            unc_for(&share, "cargo-test/a.txt").to_string(),
+            r"\\localhost\temp\cargo-test\a.txt"
+        );
+    }
+
+    #[test]
+    fn should_convert_slashes() {
+        assert_eq!(to_backslash_path("cargo-test/b.txt"), r"cargo-test\b.txt");
+    }
+
+    #[test]
+    fn should_convert_filetime() {
+        assert_eq!(filetime_to_system_time(FileTime::ZERO), None);
+        // 1970-01-01T00:00:01Z in 100 ns ticks since 1601.
+        let one_second_after_unix_epoch = FileTime::from(116_444_736_010_000_000u64);
+        assert_eq!(
+            filetime_to_system_time(one_second_after_unix_epoch),
+            Some(UNIX_EPOCH + Duration::from_secs(1))
+        );
+    }
+
+    #[test]
+    fn should_map_attributes_to_mode_and_type() {
+        let dir = FileAttributes::new().with_directory(true);
+        assert_eq!(mode_for(dir), UnixPex::from(0o755));
+        assert_eq!(file_type_for(dir), FileType::Directory);
+        let ro = FileAttributes::new().with_readonly(true);
+        assert_eq!(mode_for(ro), UnixPex::from(0o444));
+        assert_eq!(file_type_for(ro), FileType::File);
+        let link = FileAttributes::new().with_reparse_point(true);
+        assert_eq!(file_type_for(link), FileType::Symlink);
+    }
+
+    #[test]
+    fn should_map_open_info_to_file() {
+        let info = FileNetworkOpenInformation {
+            creation_time: FileTime::from(116_444_736_010_000_000u64),
+            last_access_time: FileTime::ZERO,
+            last_write_time: FileTime::from(116_444_736_020_000_000u64),
+            change_time: FileTime::ZERO,
+            allocation_size: 4096,
+            end_of_file: 10,
+            file_attributes: FileAttributes::new(),
+        };
+        let file = open_info_to_file(PathBuf::from("/cargo-test/a.txt"), &info);
+        assert_eq!(file.name(), "a.txt");
+        assert_eq!(file.path(), Path::new("/cargo-test/a.txt"));
+        assert_eq!(file.metadata().size, 10);
+        assert_eq!(file.metadata().file_type, FileType::File);
+        assert_eq!(file.metadata().accessed, None);
+        assert_eq!(
+            file.metadata().modified,
+            Some(UNIX_EPOCH + Duration::from_secs(2))
+        );
+        assert_eq!(file.metadata().mode, Some(UnixPex::from(0o644)));
+        assert_eq!(file.metadata().uid, None);
+    }
+
+    #[test]
+    fn should_wrap_smb_error() {
+        let err = smb_error(RemoteErrorType::StatFailed, smb::Error::Other("boom"));
+        assert_eq!(err.kind, RemoteErrorType::StatFailed);
+        assert!(err.msg.as_deref().unwrap().contains("boom"));
+    }
+}

--- a/src/client/rust_smb/credentials.rs
+++ b/src/client/rust_smb/credentials.rs
@@ -1,0 +1,219 @@
+//! Credentials for the Rust-native SMB client.
+
+use remotefs::{RemoteError, RemoteErrorType, RemoteResult};
+use smb::UncPath;
+
+/// Credentials used by [`SmbFs`](super::SmbFs) to reach an SMB share.
+///
+/// The builder accepts the same values as `PavaoSmbCredentials`: `server`
+/// may carry the `smb://` scheme and a port, `share` may carry a leading
+/// slash, and `workgroup` is folded into the logon name (`WORKGROUP\user`).
+///
+/// # Examples
+///
+/// ```
+/// use remotefs_smb::SmbCredentials;
+///
+/// let _credentials = SmbCredentials::default()
+///     .server("smb://localhost:3445")
+///     .share("/temp")
+///     .username("test")
+///     .password("test")
+///     .workgroup("pavao");
+/// ```
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct SmbCredentials {
+    server: String,
+    share: String,
+    username: Option<String>,
+    password: Option<String>,
+    workgroup: Option<String>,
+}
+
+/// Credentials after parsing, ready for `smb::Client::share_connect`.
+#[derive(Debug, Clone)]
+pub(super) struct ResolvedCredentials {
+    /// `\\host\share` with no path component.
+    pub share: UncPath,
+    /// Explicit TCP port, if the server string carried one.
+    pub port: Option<u16>,
+    /// Down-level logon name (`WORKGROUP\user`) or plain user name.
+    pub logon_name: String,
+    /// Password, empty when not provided.
+    pub password: String,
+}
+
+impl SmbCredentials {
+    /// Sets the server, as `smb://host[:port]`, `host[:port]`, or `\\host`.
+    pub fn server<S: AsRef<str>>(mut self, server: S) -> Self {
+        self.server = server.as_ref().to_string();
+        self
+    }
+
+    /// Sets the share name; a leading slash is tolerated.
+    pub fn share<S: AsRef<str>>(mut self, share: S) -> Self {
+        self.share = share.as_ref().to_string();
+        self
+    }
+
+    /// Sets the user name.
+    pub fn username<S: AsRef<str>>(mut self, username: S) -> Self {
+        self.username = Some(username.as_ref().to_string());
+        self
+    }
+
+    /// Sets the password.
+    pub fn password<S: AsRef<str>>(mut self, password: S) -> Self {
+        self.password = Some(password.as_ref().to_string());
+        self
+    }
+
+    /// Sets the workgroup (NetBIOS domain) used for NTLM authentication.
+    pub fn workgroup<S: AsRef<str>>(mut self, workgroup: S) -> Self {
+        self.workgroup = Some(workgroup.as_ref().to_string());
+        self
+    }
+
+    /// Parses the credentials into the pieces the `smb` crate needs.
+    pub(super) fn resolve(&self) -> RemoteResult<ResolvedCredentials> {
+        let (host, port) = parse_server(&self.server)?;
+        let share = self.share.trim_matches(['/', '\\']);
+        if share.is_empty() {
+            return Err(bad_address("share name is empty"));
+        }
+        let share = UncPath::new(&host)
+            .and_then(|unc| unc.with_share(share))
+            .map_err(bad_address)?;
+        let username = self.username.clone().unwrap_or_default();
+        let logon_name = match self.workgroup.as_deref() {
+            Some(workgroup) if !workgroup.is_empty() && !username.is_empty() => {
+                format!("{workgroup}\\{username}")
+            }
+            _ => username,
+        };
+        Ok(ResolvedCredentials {
+            share,
+            port,
+            logon_name,
+            password: self.password.clone().unwrap_or_default(),
+        })
+    }
+}
+
+/// Splits `smb://host[:port]` (scheme and slashes optional) into host and port.
+pub(super) fn parse_server(server: &str) -> RemoteResult<(String, Option<u16>)> {
+    let server = server.strip_prefix("smb://").unwrap_or(server);
+    let server = server.trim_matches(['/', '\\']);
+    if server.is_empty() {
+        return Err(bad_address("server is empty"));
+    }
+    match server.rsplit_once(':') {
+        Some((host, port)) if !host.is_empty() => {
+            let port = port
+                .parse::<u16>()
+                .map_err(|_| bad_address(format!("invalid port '{port}'")))?;
+            Ok((host.to_string(), Some(port)))
+        }
+        Some(_) => Err(bad_address("server host is empty")),
+        None => Ok((server.to_string(), None)),
+    }
+}
+
+fn bad_address<S: ToString>(msg: S) -> RemoteError {
+    RemoteError::new_ex(RemoteErrorType::BadAddress, msg)
+}
+
+#[cfg(test)]
+mod test {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn should_parse_server_with_scheme_and_port() {
+        assert_eq!(
+            parse_server("smb://localhost:3445").unwrap(),
+            ("localhost".to_string(), Some(3445))
+        );
+    }
+
+    #[test]
+    fn should_parse_server_without_scheme_or_port() {
+        assert_eq!(
+            parse_server("fileserver").unwrap(),
+            ("fileserver".to_string(), None)
+        );
+        assert_eq!(
+            parse_server("//fileserver/").unwrap(),
+            ("fileserver".to_string(), None)
+        );
+        assert_eq!(
+            parse_server(r"\\fileserver").unwrap(),
+            ("fileserver".to_string(), None)
+        );
+    }
+
+    #[test]
+    fn should_reject_empty_or_bad_server() {
+        assert_eq!(
+            parse_server("").unwrap_err().kind,
+            RemoteErrorType::BadAddress
+        );
+        assert_eq!(
+            parse_server("smb://").unwrap_err().kind,
+            RemoteErrorType::BadAddress
+        );
+        assert_eq!(
+            parse_server("host:notaport").unwrap_err().kind,
+            RemoteErrorType::BadAddress
+        );
+    }
+
+    #[test]
+    fn should_resolve_credentials() {
+        let resolved = SmbCredentials::default()
+            .server("smb://localhost:3445")
+            .share("/temp")
+            .username("test")
+            .password("secret")
+            .workgroup("pavao")
+            .resolve()
+            .unwrap();
+        assert_eq!(resolved.share.to_string(), r"\\localhost\temp");
+        assert_eq!(resolved.port, Some(3445));
+        assert_eq!(resolved.logon_name, r"pavao\test");
+        assert_eq!(resolved.password, "secret");
+    }
+
+    #[test]
+    fn should_resolve_anonymous_credentials_without_workgroup() {
+        let resolved = SmbCredentials::default()
+            .server("fileserver")
+            .share("public")
+            .resolve()
+            .unwrap();
+        assert_eq!(resolved.share.to_string(), r"\\fileserver\public");
+        assert_eq!(resolved.port, None);
+        assert_eq!(resolved.logon_name, "");
+        assert_eq!(resolved.password, "");
+    }
+
+    #[test]
+    fn should_reject_missing_share() {
+        let err = SmbCredentials::default()
+            .server("fileserver")
+            .resolve()
+            .unwrap_err();
+        assert_eq!(err.kind, RemoteErrorType::BadAddress);
+    }
+
+    #[test]
+    fn should_reject_share_with_path() {
+        let err = SmbCredentials::default()
+            .server("fileserver")
+            .share("temp/sub")
+            .resolve()
+            .unwrap_err();
+        assert_eq!(err.kind, RemoteErrorType::BadAddress);
+    }
+}

--- a/src/client/rust_smb/options.rs
+++ b/src/client/rust_smb/options.rs
@@ -1,0 +1,263 @@
+//! Options for the Rust-native SMB client.
+
+use std::time::Duration;
+
+use remotefs::{RemoteError, RemoteErrorType, RemoteResult};
+use smb::connection::EncryptionMode;
+use smb::{ClientConfig, ConnectionConfig};
+
+use crate::SmbDialect;
+
+/// Transport encryption policy for [`SmbFs`](super::SmbFs).
+///
+/// Variants mirror `PavaoSmbEncryptionLevel`.
+///
+/// # Examples
+///
+/// ```
+/// use remotefs_smb::SmbEncryptionLevel;
+///
+/// assert_eq!(SmbEncryptionLevel::default(), SmbEncryptionLevel::Request);
+/// ```
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum SmbEncryptionLevel {
+    /// Never encrypt, even if the server asks for it.
+    None,
+    /// Encrypt when the server supports it (default).
+    #[default]
+    Request,
+    /// Fail the connection unless the server encrypts.
+    Require,
+}
+
+impl From<SmbEncryptionLevel> for EncryptionMode {
+    fn from(value: SmbEncryptionLevel) -> Self {
+        match value {
+            SmbEncryptionLevel::None => Self::Disabled,
+            SmbEncryptionLevel::Request => Self::Allowed,
+            SmbEncryptionLevel::Require => Self::Required,
+        }
+    }
+}
+
+/// Connection options for [`SmbFs`](super::SmbFs).
+///
+/// # Examples
+///
+/// ```
+/// use std::time::Duration;
+///
+/// use remotefs_smb::{SmbEncryptionLevel, SmbOptions};
+///
+/// let _options = SmbOptions::default()
+///     .encryption_level(SmbEncryptionLevel::Require)
+///     .compression(true)
+///     .timeout(Duration::from_secs(5));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SmbOptions {
+    encryption_level: SmbEncryptionLevel,
+    compression: bool,
+    dfs: bool,
+    timeout: Option<Duration>,
+}
+
+impl Default for SmbOptions {
+    fn default() -> Self {
+        Self {
+            encryption_level: SmbEncryptionLevel::Request,
+            compression: false,
+            dfs: true,
+            timeout: None,
+        }
+    }
+}
+
+impl SmbOptions {
+    /// Sets the encryption policy. Defaults to [`SmbEncryptionLevel::Request`].
+    pub fn encryption_level(mut self, level: SmbEncryptionLevel) -> Self {
+        self.encryption_level = level;
+        self
+    }
+
+    /// Enables SMB 3.1.1 compression when the server supports it. Off by default.
+    pub fn compression(mut self, enabled: bool) -> Self {
+        self.compression = enabled;
+        self
+    }
+
+    /// Enables DFS referral resolution. On by default.
+    pub fn dfs(mut self, enabled: bool) -> Self {
+        self.dfs = enabled;
+        self
+    }
+
+    /// Sets the request timeout. Defaults to the `smb` crate's 10 seconds.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+}
+
+/// Converts the crate dialect into the `smb` crate dialect.
+///
+/// Returns `None` for [`SmbDialect::Nt1`], which the pure-Rust client cannot
+/// speak.
+pub(super) fn to_smb_dialect(dialect: SmbDialect) -> Option<smb::Dialect> {
+    match dialect {
+        SmbDialect::Nt1 => None,
+        SmbDialect::Smb202 => Some(smb::Dialect::Smb0202),
+        SmbDialect::Smb210 => Some(smb::Dialect::Smb021),
+        SmbDialect::Smb300 => Some(smb::Dialect::Smb030),
+        SmbDialect::Smb302 => Some(smb::Dialect::Smb0302),
+        SmbDialect::Smb311 => Some(smb::Dialect::Smb0311),
+    }
+}
+
+/// Assembles and validates the `smb::ClientConfig` for a connection.
+pub(super) fn build_client_config(
+    options: &SmbOptions,
+    port: Option<u16>,
+    min_dialect: SmbDialect,
+    max_dialect: SmbDialect,
+) -> RemoteResult<ClientConfig> {
+    let min_dialect = to_smb_dialect(min_dialect).ok_or_else(nt1_unsupported)?;
+    let max_dialect = to_smb_dialect(max_dialect).ok_or_else(nt1_unsupported)?;
+    let connection = ConnectionConfig {
+        port,
+        timeout: options.timeout,
+        min_dialect: Some(min_dialect),
+        max_dialect: Some(max_dialect),
+        encryption_mode: options.encryption_level.into(),
+        compression_enabled: options.compression,
+        ..ConnectionConfig::default()
+    };
+    connection
+        .validate()
+        .map_err(|e| RemoteError::new_ex(RemoteErrorType::BadAddress, e))?;
+    Ok(ClientConfig {
+        dfs: options.dfs,
+        connection,
+        ..ClientConfig::default()
+    })
+}
+
+fn nt1_unsupported() -> RemoteError {
+    RemoteError::new_ex(
+        RemoteErrorType::BadAddress,
+        "the SMB1/CIFS NT1 dialect is not supported by the Rust-native client",
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use std::time::Duration;
+
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn should_convert_supported_dialects() {
+        assert_eq!(
+            to_smb_dialect(SmbDialect::Smb202),
+            Some(smb::Dialect::Smb0202)
+        );
+        assert_eq!(
+            to_smb_dialect(SmbDialect::Smb210),
+            Some(smb::Dialect::Smb021)
+        );
+        assert_eq!(
+            to_smb_dialect(SmbDialect::Smb300),
+            Some(smb::Dialect::Smb030)
+        );
+        assert_eq!(
+            to_smb_dialect(SmbDialect::Smb302),
+            Some(smb::Dialect::Smb0302)
+        );
+        assert_eq!(
+            to_smb_dialect(SmbDialect::Smb311),
+            Some(smb::Dialect::Smb0311)
+        );
+    }
+
+    #[test]
+    fn should_not_convert_nt1() {
+        assert_eq!(to_smb_dialect(SmbDialect::Nt1), None);
+    }
+
+    #[test]
+    fn should_convert_encryption_levels() {
+        assert_eq!(
+            EncryptionMode::from(SmbEncryptionLevel::None),
+            EncryptionMode::Disabled
+        );
+        assert_eq!(
+            EncryptionMode::from(SmbEncryptionLevel::Request),
+            EncryptionMode::Allowed
+        );
+        assert_eq!(
+            EncryptionMode::from(SmbEncryptionLevel::Require),
+            EncryptionMode::Required
+        );
+    }
+
+    #[test]
+    fn should_build_default_client_config() {
+        let config = build_client_config(
+            &SmbOptions::default(),
+            Some(3445),
+            SmbDialect::Smb202,
+            SmbDialect::Smb311,
+        )
+        .unwrap();
+        assert!(config.dfs);
+        assert_eq!(config.connection.port, Some(3445));
+        assert_eq!(config.connection.min_dialect, Some(smb::Dialect::Smb0202));
+        assert_eq!(config.connection.max_dialect, Some(smb::Dialect::Smb0311));
+        assert_eq!(config.connection.encryption_mode, EncryptionMode::Allowed);
+        assert!(!config.connection.compression_enabled);
+        assert_eq!(config.connection.timeout, None);
+        assert!(config.connection.auth_methods.ntlm);
+    }
+
+    #[test]
+    fn should_apply_options() {
+        let options = SmbOptions::default()
+            .encryption_level(SmbEncryptionLevel::Require)
+            .compression(true)
+            .dfs(false)
+            .timeout(Duration::from_secs(3));
+        let config =
+            build_client_config(&options, None, SmbDialect::Smb300, SmbDialect::Smb311).unwrap();
+        assert!(!config.dfs);
+        assert_eq!(config.connection.port, None);
+        assert_eq!(config.connection.encryption_mode, EncryptionMode::Required);
+        assert!(config.connection.compression_enabled);
+        assert_eq!(config.connection.timeout, Some(Duration::from_secs(3)));
+    }
+
+    #[test]
+    fn should_reject_nt1_bounds() {
+        let err = build_client_config(
+            &SmbOptions::default(),
+            None,
+            SmbDialect::Nt1,
+            SmbDialect::Smb311,
+        )
+        .unwrap_err();
+        assert_eq!(err.kind, RemoteErrorType::BadAddress);
+    }
+
+    #[test]
+    fn should_reject_inverted_bounds() {
+        let err = build_client_config(
+            &SmbOptions::default(),
+            None,
+            SmbDialect::Smb311,
+            SmbDialect::Smb202,
+        )
+        .unwrap_err();
+        assert_eq!(err.kind, RemoteErrorType::BadAddress);
+    }
+}

--- a/src/client/unix.rs
+++ b/src/client/unix.rs
@@ -7,7 +7,11 @@ use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 
 use libc::mode_t;
-pub use pavao::{SmbClient, SmbCredentials, SmbEncryptionLevel, SmbOptions, SmbShareMode};
+pub use pavao::{
+    SmbClient, SmbCredentials as PavaoSmbCredentials,
+    SmbEncryptionLevel as PavaoSmbEncryptionLevel, SmbOptions as PavaoSmbOptions,
+    SmbShareMode as PavaoSmbShareMode,
+};
 use pavao::{SmbDirentType, SmbMode, SmbOpenOptions};
 use remotefs::fs::{File, Metadata, ReadStream, UnixPex, Welcome, WriteStream};
 use remotefs::{RemoteError, RemoteErrorType, RemoteFs, RemoteResult};
@@ -28,13 +32,13 @@ impl From<SmbDialect> for pavao::SmbDialect {
     }
 }
 
-/// SMB file system client
-pub struct SmbFs {
+/// SMB file system client backed by pavao (libsmbclient).
+pub struct PavaoSmbFs {
     client: SmbClient,
     wrkdir: PathBuf,
 }
 
-impl SmbFs {
+impl PavaoSmbFs {
     /// Tries to create an SMB client with secure automatic dialect bounds.
     ///
     /// Automatic negotiation is limited to SMB2 through SMB3.1.1 and excludes
@@ -48,17 +52,20 @@ impl SmbFs {
     /// # Examples
     ///
     /// ```no_run
-    /// use remotefs_smb::{SmbCredentials, SmbFs, SmbOptions};
+    /// use remotefs_smb::{PavaoSmbCredentials, PavaoSmbFs, PavaoSmbOptions};
     ///
-    /// let _client = SmbFs::try_new(
-    ///     SmbCredentials::default()
+    /// let _client = PavaoSmbFs::try_new(
+    ///     PavaoSmbCredentials::default()
     ///         .server("smb://server.example")
     ///         .share("/documents"),
-    ///     SmbOptions::default(),
+    ///     PavaoSmbOptions::default(),
     /// )?;
     /// # Ok::<(), remotefs::RemoteError>(())
     /// ```
-    pub fn try_new(credentials: SmbCredentials, options: SmbOptions) -> RemoteResult<Self> {
+    pub fn try_new(
+        credentials: PavaoSmbCredentials,
+        options: PavaoSmbOptions,
+    ) -> RemoteResult<Self> {
         Self::try_new_with_dialect(credentials, options, AUTO_MIN_DIALECT, AUTO_MAX_DIALECT)
     }
 
@@ -77,21 +84,21 @@ impl SmbFs {
     /// # Examples
     ///
     /// ```no_run
-    /// use remotefs_smb::{SmbCredentials, SmbDialect, SmbFs, SmbOptions};
+    /// use remotefs_smb::{PavaoSmbCredentials, PavaoSmbFs, PavaoSmbOptions, SmbDialect};
     ///
-    /// let _client = SmbFs::try_new_with_dialect(
-    ///     SmbCredentials::default()
+    /// let _client = PavaoSmbFs::try_new_with_dialect(
+    ///     PavaoSmbCredentials::default()
     ///         .server("smb://server.example")
     ///         .share("/documents"),
-    ///     SmbOptions::default(),
+    ///     PavaoSmbOptions::default(),
     ///     SmbDialect::Smb202,
     ///     SmbDialect::Smb210,
     /// )?;
     /// # Ok::<(), remotefs::RemoteError>(())
     /// ```
     pub fn try_new_with_dialect(
-        credentials: SmbCredentials,
-        options: SmbOptions,
+        credentials: PavaoSmbCredentials,
+        options: PavaoSmbOptions,
         min_dialect: SmbDialect,
         max_dialect: SmbDialect,
     ) -> RemoteResult<Self> {
@@ -137,7 +144,7 @@ impl SmbFs {
     }
 }
 
-impl RemoteFs for SmbFs {
+impl RemoteFs for PavaoSmbFs {
     fn connect(&mut self) -> RemoteResult<Welcome> {
         // Get user to check whether connection works
         self.check_connection()?;
@@ -396,9 +403,9 @@ mod test {
     #[test]
     #[serial]
     fn should_reject_inverted_dialect_bounds() {
-        let result = SmbFs::try_new_with_dialect(
+        let result = PavaoSmbFs::try_new_with_dialect(
             test_credentials(),
-            SmbOptions::default(),
+            PavaoSmbOptions::default(),
             SmbDialect::Smb311,
             SmbDialect::Nt1,
         );
@@ -412,10 +419,11 @@ mod test {
     #[test]
     #[serial]
     fn should_default_to_secure_auto_dialect_bounds() {
-        let default_client = SmbFs::try_new(test_credentials(), SmbOptions::default()).unwrap();
-        let explicit_auto_client = SmbFs::try_new_with_dialect(
+        let default_client =
+            PavaoSmbFs::try_new(test_credentials(), PavaoSmbOptions::default()).unwrap();
+        let explicit_auto_client = PavaoSmbFs::try_new_with_dialect(
             test_credentials(),
-            SmbOptions::default(),
+            PavaoSmbOptions::default(),
             SmbDialect::Smb202,
             SmbDialect::Smb311,
         );
@@ -950,8 +958,8 @@ mod test {
 
     fn is_sync<T: Sync>(_sync: T) {}
 
-    fn test_credentials() -> SmbCredentials {
-        SmbCredentials::default()
+    fn test_credentials() -> PavaoSmbCredentials {
+        PavaoSmbCredentials::default()
             .server("smb://localhost:3445")
             .share("/temp")
             .username("test")
@@ -961,9 +969,9 @@ mod test {
 
     #[test]
     fn test_should_be_sync() {
-        let client = SmbFs::try_new(
+        let client = PavaoSmbFs::try_new(
             test_credentials(),
-            SmbOptions::default()
+            PavaoSmbOptions::default()
                 .case_sensitive(true)
                 .one_share_per_server(true),
         )
@@ -974,9 +982,9 @@ mod test {
 
     #[test]
     fn test_should_be_send() {
-        let client = SmbFs::try_new(
+        let client = PavaoSmbFs::try_new(
             test_credentials(),
-            SmbOptions::default()
+            PavaoSmbOptions::default()
                 .case_sensitive(true)
                 .one_share_per_server(true),
         )
@@ -986,10 +994,10 @@ mod test {
     }
 
     #[cfg(feature = "with-containers")]
-    fn init_client() -> SmbFs {
-        let mut client = SmbFs::try_new(
+    fn init_client() -> PavaoSmbFs {
+        let mut client = PavaoSmbFs::try_new(
             test_credentials(),
-            SmbOptions::default()
+            PavaoSmbOptions::default()
                 .case_sensitive(true)
                 .one_share_per_server(true),
         )
@@ -1005,7 +1013,7 @@ mod test {
     }
 
     #[cfg(feature = "with-containers")]
-    fn finalize_client(mut client: SmbFs) {
+    fn finalize_client(mut client: PavaoSmbFs) {
         let _ = client.remove_dir_all(Path::new("/cargo-test"));
         std::thread::sleep(Duration::from_secs(1));
         drop(client);

--- a/src/client/windows.rs
+++ b/src/client/windows.rs
@@ -8,7 +8,7 @@ mod file_stream;
 use std::ffi::CString;
 use std::path::{Path, PathBuf};
 
-pub use credentials::SmbCredentials;
+pub use credentials::WNetSmbCredentials;
 use file_stream::FileStream;
 use filetime::{self, FileTime};
 use remotefs::fs::stream::{ReadAndSeek, WriteAndSeek};
@@ -19,16 +19,16 @@ use windows_sys::Win32::NetworkManagement::WNet;
 
 use super::{SmbDialect, AUTO_MAX_DIALECT, AUTO_MIN_DIALECT};
 
-/// SMB file system client
-pub struct SmbFs {
+/// SMB file system client backed by the Windows WNet API.
+pub struct WNetSmbFs {
     remote_path: PathBuf,
     remote_name: String,
-    credentials: SmbCredentials,
+    credentials: WNetSmbCredentials,
     wrkdir: PathBuf,
     is_connected: bool,
 }
 
-impl SmbFs {
+impl WNetSmbFs {
     /// Instantiates an SMB client with secure automatic dialect bounds.
     ///
     /// The portable policy represented by this constructor allows SMB2 through
@@ -39,11 +39,11 @@ impl SmbFs {
     /// # Examples
     ///
     /// ```no_run
-    /// use remotefs_smb::{SmbCredentials, SmbFs};
+    /// use remotefs_smb::{WNetSmbCredentials, WNetSmbFs};
     ///
-    /// let _client = SmbFs::new(SmbCredentials::new("server.example", "documents"));
+    /// let _client = WNetSmbFs::new(WNetSmbCredentials::new("server.example", "documents"));
     /// ```
-    pub fn new(credentials: SmbCredentials) -> Self {
+    pub fn new(credentials: WNetSmbCredentials) -> Self {
         Self::new_with_dialect(credentials, AUTO_MIN_DIALECT, AUTO_MAX_DIALECT)
     }
 
@@ -58,16 +58,16 @@ impl SmbFs {
     /// # Examples
     ///
     /// ```no_run
-    /// use remotefs_smb::{SmbCredentials, SmbDialect, SmbFs};
+    /// use remotefs_smb::{SmbDialect, WNetSmbCredentials, WNetSmbFs};
     ///
-    /// let _client = SmbFs::new_with_dialect(
-    ///     SmbCredentials::new("server.example", "documents"),
+    /// let _client = WNetSmbFs::new_with_dialect(
+    ///     WNetSmbCredentials::new("server.example", "documents"),
     ///     SmbDialect::Smb202,
     ///     SmbDialect::Smb210,
     /// );
     /// ```
     pub fn new_with_dialect(
-        credentials: SmbCredentials,
+        credentials: WNetSmbCredentials,
         _min_dialect: SmbDialect,
         _max_dialect: SmbDialect,
     ) -> Self {
@@ -108,7 +108,7 @@ impl SmbFs {
     }
 }
 
-impl RemoteFs for SmbFs {
+impl RemoteFs for WNetSmbFs {
     fn connect(&mut self) -> RemoteResult<Welcome> {
         // add connection
         trace!("connecting to {}", self.remote_name);
@@ -419,8 +419,8 @@ mod test {
 
     #[test]
     fn should_construct_with_explicit_dialect_bounds() {
-        let client = SmbFs::new_with_dialect(
-            SmbCredentials::new("pippo", "pippo"),
+        let client = WNetSmbFs::new_with_dialect(
+            WNetSmbCredentials::new("pippo", "pippo"),
             SmbDialect::Nt1,
             SmbDialect::Nt1,
         );
@@ -431,7 +431,7 @@ mod test {
 
     #[test]
     fn should_construct_with_secure_auto_defaults() {
-        let client = SmbFs::new(SmbCredentials::new("pippo", "pippo"));
+        let client = WNetSmbFs::new(WNetSmbCredentials::new("pippo", "pippo"));
 
         assert_eq!(AUTO_MIN_DIALECT, SmbDialect::Smb202);
         assert_eq!(AUTO_MAX_DIALECT, SmbDialect::Smb311);
@@ -453,22 +453,22 @@ mod test {
 
     #[test]
     fn test_should_be_sync() {
-        let client = SmbFs::new(SmbCredentials::new("pippo", "pippo"));
+        let client = WNetSmbFs::new(WNetSmbCredentials::new("pippo", "pippo"));
 
         is_sync(client);
     }
 
     #[test]
     fn test_should_be_send() {
-        let client = SmbFs::new(SmbCredentials::new("pippo", "pippo"));
+        let client = WNetSmbFs::new(WNetSmbCredentials::new("pippo", "pippo"));
 
         is_send(client);
     }
 
     #[cfg(feature = "with-containers")]
-    fn init_client() -> SmbFs {
-        let mut client = SmbFs::new(
-            SmbCredentials::new(env!("SMB_SERVER"), env!("SMB_SHARE"))
+    fn init_client() -> WNetSmbFs {
+        let mut client = WNetSmbFs::new(
+            WNetSmbCredentials::new(env!("SMB_SERVER"), env!("SMB_SHARE"))
                 .username(env!("SMB_USERNAME"))
                 .password(env!("SMB_PASSWORD")),
         );
@@ -478,7 +478,7 @@ mod test {
     }
 
     #[cfg(feature = "with-containers")]
-    fn finalize_client(mut client: SmbFs) {
+    fn finalize_client(mut client: WNetSmbFs) {
         assert!(client.disconnect().is_ok());
     }
 }

--- a/src/client/windows/credentials.rs
+++ b/src/client/windows/credentials.rs
@@ -1,12 +1,13 @@
+/// Credentials for the Windows WNet-based client.
 #[derive(Debug, Default, Clone)]
-pub struct SmbCredentials {
+pub struct WNetSmbCredentials {
     pub(crate) server: String,
     pub(crate) share: String,
     pub(crate) username: Option<String>,
     pub(crate) password: Option<String>,
 }
 
-impl SmbCredentials {
+impl WNetSmbCredentials {
     pub fn new<S: AsRef<str>>(server: S, share: S) -> Self {
         Self {
             server: server.as_ref().to_string(),
@@ -15,13 +16,13 @@ impl SmbCredentials {
         }
     }
 
-    /// Construct SmbCredentials with the provided username
+    /// Construct WNetSmbCredentials with the provided username
     pub fn username<S: AsRef<str>>(mut self, username: S) -> Self {
         self.username = Some(username.as_ref().to_string());
         self
     }
 
-    /// Construct SmbCredentials with the provided password
+    /// Construct WNetSmbCredentials with the provided password
     pub fn password<S: AsRef<str>>(mut self, password: S) -> Self {
         self.password = Some(password.as_ref().to_string());
         self
@@ -37,7 +38,7 @@ mod test {
 
     #[test]
     fn should_init_credentials() {
-        let credentials = SmbCredentials::new("localhost", "temp");
+        let credentials = WNetSmbCredentials::new("localhost", "temp");
         assert_eq!(&credentials.server, "localhost");
         assert_eq!(&credentials.share, "temp");
         assert!(credentials.username.is_none());
@@ -46,7 +47,7 @@ mod test {
 
     #[test]
     fn should_construct_credentials() {
-        let credentials = SmbCredentials::new("localhost", "temp")
+        let credentials = WNetSmbCredentials::new("localhost", "temp")
             .username("test")
             .password("foobar");
         assert_eq!(&credentials.server, "localhost");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,37 +1,67 @@
 #![crate_name = "remotefs_smb"]
 #![crate_type = "lib"]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! # remotefs-smb
 //!
-//! remotefs-smb is a client implementation for [remotefs](https://github.com/remotefs-rs/remotefs-rs), providing support for the SMB protocol.
+//! remotefs-smb is a client implementation for
+//! [remotefs](https://github.com/remotefs-rs/remotefs-rs), providing support
+//! for the SMB protocol.
+//!
+//! Three clients are available:
+//!
+//! - **Rust-native client** (`smb` feature, every platform): `SmbFs`, a
+//!   pure-Rust implementation built on the [smb](https://crates.io/crates/smb)
+//!   crate. Supports SMB 2.0.2 through 3.1.1, needs no system library, and
+//!   requires a Tokio runtime supplied by the caller.
+//! - **pavao client** (`pavao` feature, UNIX only): `PavaoSmbFs`, a binding
+//!   to `libsmbclient` through the [pavao](https://github.com/veeso/pavao)
+//!   crate. Supports SMB1 through SMB 3.1.1 and needs `libsmbclient`
+//!   installed.
+//! - **WNet client** (Windows only, always available): `WNetSmbFs`, built on
+//!   the Win32 `WNet` API.
+//!
+//! `pavao` and `smb` can be enabled together.
 //!
 //! ## Get started
 //!
-//! First of all you need to add **remotefs** and the client to your project dependencies:
+//! First of all you need to add **remotefs** and the client to your project
+//! dependencies:
 //!
 //! ```toml
 //! remotefs = "^0.3"
-//! remotefs-smb = "^0.3"
+//! remotefs-smb = "^0.5"
 //! ```
 //!
-//! these features are supported:
+//! These features are supported:
 //!
+//! - `pavao`: enable the `libsmbclient`-based client on UNIX (*enabled by
+//!   default*)
+//! - `smb`: enable the Rust-native client on every platform
 //! - `find`: enable `find()` method for RemoteFs. (*enabled by default*)
-//! - `no-log`: disable logging. By default, this library will log via the `log` crate.
+//! - `no-log`: disable logging. By default, this library will log via the
+//!   `log` crate.
+//! - `vendored`: build pavao with a vendored `libsmbclient` (implies `pavao`)
 //!
+//! ### Rust-native client (all platforms)
 //!
-//! ### Smb client (UNIX)
-//!
-//! Here is a basic usage example, with the `Smb` client.
+//! `SmbFs` takes the same credentials shape as the pavao client plus an
+//! `Arc<tokio::runtime::Runtime>` that it uses to drive the asynchronous `smb`
+//! crate. Add `tokio = { version = "1", features = ["rt-multi-thread"] }`
+//! to your dependencies and enable the `smb` feature.
 //! `SmbFs::try_new` automatically negotiates only SMB2 through SMB3.1.1.
 //!
 //! ```rust,no_run
-//!
-//! // import remotefs trait and client
-//! use remotefs::{RemoteFs, fs::UnixPex};
-//! use remotefs_smb::{SmbFs, SmbOptions, SmbCredentials};
+//! # #[cfg(feature = "smb")]
+//! # {
 //! use std::path::Path;
+//! use std::sync::Arc;
 //!
+//! use remotefs::{fs::UnixPex, RemoteFs};
+//! use remotefs_smb::{SmbCredentials, SmbFs, SmbOptions};
+//! use tokio::runtime::Runtime;
+//!
+//! let runtime = Arc::new(Runtime::new().unwrap());
 //! let mut client = SmbFs::try_new(
 //!     SmbCredentials::default()
 //!         .server("smb://localhost:3445")
@@ -39,39 +69,104 @@
 //!         .username("test")
 //!         .password("test")
 //!         .workgroup("pavao"),
-//!     SmbOptions::default()
-//!         .case_sensitive(true)
-//!         .one_share_per_server(true),
+//!     SmbOptions::default(),
+//!     &runtime,
 //! )
 //! .unwrap();
 //!
-//! // connect
 //! assert!(client.connect().is_ok());
-//! // get working directory
-//! println!("Wrkdir: {}", client.pwd().ok().unwrap().display());
-//! // make directory
-//! assert!(client.create_dir(Path::new("/cargo"), UnixPex::from(0o755)).is_ok());
-//! // change working directory
+//! println!("Wrkdir: {}", client.pwd().unwrap().display());
+//! assert!(client
+//!     .create_dir(Path::new("/cargo"), UnixPex::from(0o755))
+//!     .is_ok());
 //! assert!(client.change_dir(Path::new("/cargo")).is_ok());
-//! // disconnect
 //! assert!(client.disconnect().is_ok());
+//! # }
 //! ```
 //!
 //! To select a narrower inclusive range explicitly, use
-//! [`SmbFs::try_new_with_dialect`]:
+//! `SmbFs::try_new_with_dialect`:
 //!
 //! ```rust,no_run
-//! use remotefs_smb::{SmbCredentials, SmbDialect, SmbFs, SmbOptions};
+//! # #[cfg(feature = "smb")]
+//! # {
+//! use std::sync::Arc;
 //!
+//! use remotefs_smb::{SmbCredentials, SmbDialect, SmbFs, SmbOptions};
+//! use tokio::runtime::Runtime;
+//!
+//! let runtime = Arc::new(Runtime::new().unwrap());
 //! let _client = SmbFs::try_new_with_dialect(
 //!     SmbCredentials::default()
 //!         .server("smb://server.example")
 //!         .share("/documents"),
 //!     SmbOptions::default(),
-//!     SmbDialect::Smb202,
-//!     SmbDialect::Smb210,
-//! )?;
-//! # Ok::<(), remotefs::RemoteError>(())
+//!     SmbDialect::Smb300,
+//!     SmbDialect::Smb311,
+//!     &runtime,
+//! )
+//! .unwrap();
+//! # }
+//! ```
+//!
+//! ### Pavao client (UNIX)
+//!
+//! `PavaoSmbFs::try_new` automatically negotiates only SMB2 through SMB3.1.1;
+//! `PavaoSmbFs::try_new_with_dialect` accepts `SmbDialect::Nt1` for legacy
+//! devices.
+//!
+//! ```rust,no_run
+//! # #[cfg(all(target_family = "unix", feature = "pavao"))]
+//! # {
+//! use std::path::Path;
+//!
+//! use remotefs::{fs::UnixPex, RemoteFs};
+//! use remotefs_smb::{PavaoSmbCredentials, PavaoSmbFs, PavaoSmbOptions};
+//!
+//! let mut client = PavaoSmbFs::try_new(
+//!     PavaoSmbCredentials::default()
+//!         .server("smb://localhost:3445")
+//!         .share("/temp")
+//!         .username("test")
+//!         .password("test")
+//!         .workgroup("pavao"),
+//!     PavaoSmbOptions::default()
+//!         .case_sensitive(true)
+//!         .one_share_per_server(true),
+//! )
+//! .unwrap();
+//!
+//! assert!(client.connect().is_ok());
+//! println!("Wrkdir: {}", client.pwd().unwrap().display());
+//! assert!(client
+//!     .create_dir(Path::new("/cargo"), UnixPex::from(0o755))
+//!     .is_ok());
+//! assert!(client.change_dir(Path::new("/cargo")).is_ok());
+//! assert!(client.disconnect().is_ok());
+//! # }
+//! ```
+//!
+//! ### WNet client (Windows)
+//!
+//! ```rust,no_run
+//! # #[cfg(target_family = "windows")]
+//! # {
+//! use std::path::Path;
+//!
+//! use remotefs::{fs::UnixPex, RemoteFs};
+//! use remotefs_smb::{WNetSmbCredentials, WNetSmbFs};
+//!
+//! let mut client = WNetSmbFs::new(
+//!     WNetSmbCredentials::new("localhost:3445", "temp")
+//!         .username("test")
+//!         .password("test"),
+//! );
+//! assert!(client.connect().is_ok());
+//! assert!(client
+//!     .create_dir(Path::new("\\cargo"), UnixPex::from(0o755))
+//!     .is_ok());
+//! assert!(client.disconnect().is_ok());
+//! # }
 //! ```
 //!
 
@@ -84,19 +179,29 @@
 )]
 
 // -- crates
+#[cfg(any(
+    all(target_family = "unix", feature = "pavao"),
+    feature = "smb",
+    target_family = "windows",
+))]
 #[macro_use]
 extern crate log;
 
 mod client;
 
 pub use client::SmbDialect;
-#[cfg(target_family = "unix")]
-pub use client::{SmbCredentials, SmbEncryptionLevel, SmbFs, SmbOptions, SmbShareMode};
+#[cfg(all(target_family = "unix", feature = "pavao"))]
+pub use client::{
+    PavaoSmbCredentials, PavaoSmbEncryptionLevel, PavaoSmbFs, PavaoSmbOptions, PavaoSmbShareMode,
+};
+#[cfg(feature = "smb")]
+#[cfg_attr(docsrs, doc(cfg(feature = "smb")))]
+pub use client::{SmbCredentials, SmbEncryptionLevel, SmbFs, SmbOptions};
 #[cfg(target_family = "windows")]
-pub use client::{SmbCredentials, SmbFs};
+pub use client::{WNetSmbCredentials, WNetSmbFs};
 
 // -- utils
-#[cfg(target_family = "unix")]
+#[cfg(any(all(target_family = "unix", feature = "pavao"), feature = "smb"))]
 pub(crate) mod utils;
 // -- mock
 #[cfg(test)]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,4 +3,5 @@
 //! `utils` is the module which provides utilities of different kind
 
 pub mod path;
+#[cfg(all(target_family = "unix", feature = "pavao"))]
 pub mod smb;


### PR DESCRIPTION
# Description

Adds `SmbFs`, a pure-Rust SMB client that works on every platform and uses a Tokio runtime supplied by the caller. It supports SMB 2.0.2 through SMB 3.1.1 and the existing pavao and native clients can now be built together through the `pavao` and `smb` features.

This is a breaking release. The Unix pavao types now use the `Pavao` prefix and the Windows types use the `WNet` prefix. The native client uses the plain `SmbFs`, `SmbCredentials`, `SmbOptions`, and `SmbEncryptionLevel` names.

The dependency audit records the transitive RSA advisory from the native SMB stack because no fixed release is available.

Fixes #

## Checklist

- [x] I have read the [AI Policy](https://github.com/remotefs-rs/remotefs-rs-smb/blob/main/AI_POLICY.md) and the [contributing guidelines](https://github.com/remotefs-rs/remotefs-rs-smb/blob/main/CONTRIBUTING.md).
- [x] I have added rustdoc documentation for any new public API.
- [x] I have added tests covering my changes.
- [x] `just check` passes locally.
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org) format (the `CHANGELOG.md` is generated from them at release time).

## AI Disclosure

I used Codex to help implement, review, document, and verify this contribution. I understand the submitted changes and take responsibility for their quality.
